### PR TITLE
Event-driven reward system, service layer refactor, and centralized Firebase schema

### DIFF
--- a/src/core/activityLogger.js
+++ b/src/core/activityLogger.js
@@ -1,0 +1,17 @@
+import { activityApi } from "./firebaseService.js";
+
+export async function logRewardActivity(reward, context = {}) {
+  await Promise.all(
+    Object.entries(reward)
+      .filter(([, value]) => value !== 0)
+      .map(([stat, value]) =>
+        activityApi.addEntry({
+          stat,
+          value,
+          source: context.source || "Unknown",
+          createdAt: Date.now(),
+          message: `+${value} ${stat.toUpperCase()} (${context.source || "Unknown"})`
+        })
+      )
+  );
+}

--- a/src/core/domainEvents.js
+++ b/src/core/domainEvents.js
@@ -1,0 +1,17 @@
+const actionListeners = new Set();
+
+export const ACTION_TYPES = Object.freeze({
+  TASK_COMPLETED: "TASK_COMPLETED",
+  DAILY_TASK_COMPLETED: "DAILY_TASK_COMPLETED",
+  HABIT_COMPLETED: "HABIT_COMPLETED",
+  FOCUS_SESSION_COMPLETED: "FOCUS_SESSION_COMPLETED"
+});
+
+export function emitActionEvent(event) {
+  actionListeners.forEach((listener) => listener(event));
+}
+
+export function subscribeActionEvents(listener) {
+  actionListeners.add(listener);
+  return () => actionListeners.delete(listener);
+}

--- a/src/core/firebase.js
+++ b/src/core/firebase.js
@@ -1,6 +1,7 @@
 export {
   getPaths,
   subscribe,
+  unsubscribeAll,
   tasksApi,
   notesApi,
   financeApi,

--- a/src/core/firebaseService.js
+++ b/src/core/firebaseService.js
@@ -11,6 +11,7 @@ import {
   remove,
   runTransaction
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js";
+import { PATHS } from "./schema.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyAPHwqlZhzpE_fR3d5LuOpmTJQoxmMC-nM",
@@ -24,19 +25,6 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const db = getDatabase(app);
-
-const paths = {
-  stats: "stats",
-  dailyTasks: "dailyTasks",
-  tasks: "tasks",
-  habits: "habits",
-  notes: "notes",
-  finance: "finance",
-  financeTransactions: "finance/transactions",
-  focusSessionState: "focus/sessionState",
-  focusSessions: "focus/sessions",
-  activityLog: "activityLog"
-};
 
 const activeListeners = new Map();
 
@@ -61,6 +49,13 @@ export function subscribe(path, callback) {
       activeListeners.delete(path);
     }
   };
+}
+
+export function unsubscribeAll() {
+  activeListeners.forEach((handler, path) => {
+    off(pathRef(path), "value", handler);
+  });
+  activeListeners.clear();
 }
 
 export async function read(path) {
@@ -91,64 +86,64 @@ export async function transaction(path, updater) {
 }
 
 export function getPaths() {
-  return paths;
+  return PATHS;
 }
 
 export const statsApi = {
-  get: () => read(paths.stats),
-  set: (stats) => write(paths.stats, stats),
-  transact: (updater) => transaction(paths.stats, updater)
+  get: () => read(PATHS.stats),
+  set: (stats) => write(PATHS.stats, stats),
+  transact: (updater) => transaction(PATHS.stats, updater)
 };
 
 export const tasksApi = {
-  add: (task) => create(paths.tasks, task),
-  subscribe: (callback) => subscribe(paths.tasks, callback),
-  getById: (taskId) => read(`${paths.tasks}/${taskId}`),
-  updateById: (taskId, value) => patch(`${paths.tasks}/${taskId}`, value),
-  deleteById: (taskId) => destroy(`${paths.tasks}/${taskId}`)
+  add: (task) => create(PATHS.tasks, task),
+  subscribe: (callback) => subscribe(PATHS.tasks, callback),
+  getById: (taskId) => read(`${PATHS.tasks}/${taskId}`),
+  updateById: (taskId, value) => patch(`${PATHS.tasks}/${taskId}`, value),
+  deleteById: (taskId) => destroy(`${PATHS.tasks}/${taskId}`)
 };
 
 export const notesApi = {
-  add: (note) => create(paths.notes, note),
-  subscribe: (callback) => subscribe(paths.notes, callback),
-  getById: (noteId) => read(`${paths.notes}/${noteId}`),
-  updateById: (noteId, value) => patch(`${paths.notes}/${noteId}`, value),
-  deleteById: (noteId) => destroy(`${paths.notes}/${noteId}`)
+  add: (note) => create(PATHS.notes, note),
+  subscribe: (callback) => subscribe(PATHS.notes, callback),
+  getById: (noteId) => read(`${PATHS.notes}/${noteId}`),
+  updateById: (noteId, value) => patch(`${PATHS.notes}/${noteId}`, value),
+  deleteById: (noteId) => destroy(`${PATHS.notes}/${noteId}`)
 };
 
 export const financeApi = {
-  addTransaction: (tx) => create(paths.financeTransactions, tx),
-  subscribeTransactions: (callback) => subscribe(paths.financeTransactions, callback),
-  patchFinance: (value) => patch(paths.finance, value),
-  getTransactionById: (txId) => read(`${paths.financeTransactions}/${txId}`),
-  updateTransactionById: (txId, value) => patch(`${paths.financeTransactions}/${txId}`, value),
-  deleteTransactionById: (txId) => destroy(`${paths.financeTransactions}/${txId}`)
+  addTransaction: (tx) => create(PATHS.financeTransactions, tx),
+  subscribeTransactions: (callback) => subscribe(PATHS.financeTransactions, callback),
+  patchFinance: (value) => patch(PATHS.finance, value),
+  getTransactionById: (txId) => read(`${PATHS.financeTransactions}/${txId}`),
+  updateTransactionById: (txId, value) => patch(`${PATHS.financeTransactions}/${txId}`, value),
+  deleteTransactionById: (txId) => destroy(`${PATHS.financeTransactions}/${txId}`)
 };
 
 export const dailyTasksApi = {
-  subscribe: (callback) => subscribe(paths.dailyTasks, callback),
-  getById: (taskId) => read(`${paths.dailyTasks}/${taskId}`),
-  patchById: (taskId, value) => patch(`${paths.dailyTasks}/${taskId}`, value)
+  subscribe: (callback) => subscribe(PATHS.dailyTasks, callback),
+  getById: (taskId) => read(`${PATHS.dailyTasks}/${taskId}`),
+  patchById: (taskId, value) => patch(`${PATHS.dailyTasks}/${taskId}`, value)
 };
 
 export const habitsApi = {
-  subscribe: (callback) => subscribe(paths.habits, callback),
-  getById: (habitId) => read(`${paths.habits}/${habitId}`),
-  patchById: (habitId, value) => patch(`${paths.habits}/${habitId}`, value)
+  subscribe: (callback) => subscribe(PATHS.habits, callback),
+  getById: (habitId) => read(`${PATHS.habits}/${habitId}`),
+  patchById: (habitId, value) => patch(`${PATHS.habits}/${habitId}`, value)
 };
 
 export const focusApi = {
-  getSessionState: () => read(paths.focusSessionState),
-  setSessionState: (state) => write(paths.focusSessionState, state),
-  clearSessionState: () => write(paths.focusSessionState, null),
-  addSession: (session) => create(paths.focusSessions, session),
-  subscribeSessions: (callback) => subscribe(paths.focusSessions, callback),
-  getSessionById: (sessionId) => read(`${paths.focusSessions}/${sessionId}`),
-  updateSessionById: (sessionId, value) => patch(`${paths.focusSessions}/${sessionId}`, value),
-  deleteSessionById: (sessionId) => destroy(`${paths.focusSessions}/${sessionId}`)
+  getSessionState: () => read(PATHS.focusSessionState),
+  setSessionState: (state) => write(PATHS.focusSessionState, state),
+  clearSessionState: () => write(PATHS.focusSessionState, null),
+  addSession: (session) => create(PATHS.focusSessions, session),
+  subscribeSessions: (callback) => subscribe(PATHS.focusSessions, callback),
+  getSessionById: (sessionId) => read(`${PATHS.focusSessions}/${sessionId}`),
+  updateSessionById: (sessionId, value) => patch(`${PATHS.focusSessions}/${sessionId}`, value),
+  deleteSessionById: (sessionId) => destroy(`${PATHS.focusSessions}/${sessionId}`)
 };
 
 export const activityApi = {
-  addEntry: (entry) => create(paths.activityLog, entry),
-  subscribe: (callback) => subscribe(paths.activityLog, callback)
+  addEntry: (entry) => create(PATHS.activityLog, entry),
+  subscribe: (callback) => subscribe(PATHS.activityLog, callback)
 };

--- a/src/core/rewardEngine.js
+++ b/src/core/rewardEngine.js
@@ -1,5 +1,7 @@
-import { statsApi, activityApi } from "./firebaseService.js";
+import { statsApi } from "./firebaseService.js";
 import { resolveReward, applyLevelUps, applyRewardLocally } from "./rewardLogic.js";
+import { ACTION_TYPES, subscribeActionEvents } from "./domainEvents.js";
+import { logRewardActivity } from "./activityLogger.js";
 
 export { resolveReward, applyLevelUps, applyRewardLocally };
 
@@ -11,19 +13,50 @@ export async function applyReward(rawReward, context = {}) {
     return result.next;
   });
 
-  await Promise.all(
-    Object.entries(reward)
-      .filter(([, value]) => value !== 0)
-      .map(([stat, value]) =>
-        activityApi.addEntry({
-          stat,
-          value,
-          source: context.source || "Unknown",
-          createdAt: Date.now(),
-          message: `+${value} ${stat.toUpperCase()} (${context.source || "Unknown"})`
-        })
-      )
-  );
+  await logRewardActivity(reward, context);
 
   return next;
+}
+
+function resolveEventReward(event) {
+  switch (event.type) {
+    case ACTION_TYPES.TASK_COMPLETED:
+      return {
+        reward: event.payload?.task?.reward || { exp: 20 },
+        source: event.payload?.task?.title || "Task"
+      };
+    case ACTION_TYPES.DAILY_TASK_COMPLETED:
+      return {
+        reward: event.payload?.task?.reward || {},
+        source: event.payload?.task?.title || "Daily Task"
+      };
+    case ACTION_TYPES.HABIT_COMPLETED:
+      return {
+        reward: event.payload?.habit?.reward || {},
+        source: event.payload?.habit?.title || "Habit"
+      };
+    case ACTION_TYPES.FOCUS_SESSION_COMPLETED:
+      return {
+        reward: { foc: 5, exp: 10 },
+        source: "Focus Session"
+      };
+    default:
+      return null;
+  }
+}
+
+export function initRewardEngine({ notifyError } = {}) {
+  return subscribeActionEvents(async (event) => {
+    const resolved = resolveEventReward(event);
+    if (!resolved) return;
+    try {
+      await applyReward(resolved.reward, { source: resolved.source });
+    } catch (error) {
+      if (notifyError) {
+        notifyError(error, "Failed to apply reward");
+      } else {
+        console.error(error);
+      }
+    }
+  });
 }

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -1,0 +1,12 @@
+export const PATHS = Object.freeze({
+  stats: "stats",
+  dailyTasks: "dailyTasks",
+  tasks: "tasks",
+  habits: "habits",
+  notes: "notes",
+  finance: "finance",
+  financeTransactions: "finance/transactions",
+  focusSessionState: "focus/sessionState",
+  focusSessions: "focus/sessions",
+  activityLog: "activityLog"
+});

--- a/src/modules/focus.js
+++ b/src/modules/focus.js
@@ -1,5 +1,10 @@
-import { focusApi } from "../core/firebase.js";
-import { applyReward } from "../core/rewardEngine.js";
+import {
+  startFocusSession,
+  finalizeFocusSession,
+  subscribeFocusSessions,
+  getFocusSessionState,
+  deleteFocusSession as removeFocusSession
+} from "../services/focusService.js";
 
 function buildActions(actions) {
   const wrap = document.createElement("div");
@@ -29,8 +34,7 @@ export function initFocus(elements, notifyError) {
 
   async function finalizeSession(status) {
     if (!activeSessionId) return;
-    await focusApi.updateSessionById(activeSessionId, { status, endedAt: Date.now() });
-    await focusApi.clearSessionState();
+    await finalizeFocusSession(activeSessionId, status);
     activeSessionId = null;
     activeSessionStart = null;
     activeSessionDuration = null;
@@ -50,7 +54,6 @@ export function initFocus(elements, notifyError) {
         focusInterval = null;
         try {
           await finalizeSession("completed");
-          await applyReward({ foc: 5, exp: 10 }, { source: "Focus Session" });
         } catch (error) {
           notifyError(error, "Failed to finalize focus session");
         }
@@ -66,25 +69,10 @@ export function initFocus(elements, notifyError) {
     if (activeSessionId) return alert("A focus session is already active.");
 
     try {
-      const now = Date.now();
-      const sessionRef = await focusApi.addSession({
-        startTime: now,
-        duration: minutes,
-        status: "active",
-        endedAt: null,
-        createdAt: now
-      });
-
-      activeSessionId = sessionRef.key;
-      activeSessionStart = now;
-      activeSessionDuration = minutes;
-
-      await focusApi.setSessionState({
-        focusSessionActive: true,
-        sessionId: activeSessionId,
-        startTime: activeSessionStart,
-        duration: activeSessionDuration
-      });
+      const session = await startFocusSession(minutes);
+      activeSessionId = session.sessionId;
+      activeSessionStart = session.startTime;
+      activeSessionDuration = session.duration;
 
       startFocusTimer(activeSessionStart, activeSessionDuration);
     } catch (error) {
@@ -111,7 +99,7 @@ export function initFocus(elements, notifyError) {
       if (sessionId === activeSessionId) {
         await cancelActiveFocusSession();
       }
-      await focusApi.deleteSessionById(sessionId);
+      await removeFocusSession(sessionId);
     } catch (error) {
       notifyError(error, "Failed to delete focus session");
     }
@@ -119,7 +107,7 @@ export function initFocus(elements, notifyError) {
 
   async function restoreFocusSessionIfAny() {
     try {
-      const state = await focusApi.getSessionState();
+      const state = await getFocusSessionState();
       if (!state || !state.focusSessionActive) return;
       activeSessionId = state.sessionId;
       activeSessionStart = state.startTime;
@@ -135,7 +123,7 @@ export function initFocus(elements, notifyError) {
     button.addEventListener("click", () => beginFocusSession(Number(button.dataset.duration)));
   });
 
-  const unsubscribe = focusApi.subscribeSessions((sessions) => {
+  const unsubscribe = subscribeFocusSessions((sessions) => {
     elements.focusSessionList.innerHTML = "";
     if (!sessions) return;
 

--- a/src/modules/habits.js
+++ b/src/modules/habits.js
@@ -1,5 +1,4 @@
-import { habitsApi } from "../core/firebase.js";
-import { applyReward } from "../core/rewardEngine.js";
+import { completeHabit, subscribeHabits } from "../services/habitService.js";
 
 function buildActions(actions) {
   const wrap = document.createElement("div");
@@ -13,31 +12,16 @@ function buildActions(actions) {
   return wrap;
 }
 
-function nextHabitState(habit) {
-  const today = new Date().toDateString();
-  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toDateString();
-  const last = habit.lastCompleted;
-
-  if (last === today) {
-    throw new Error("Habit already completed today");
-  }
-
-  const streak = last === yesterday ? (habit.streak || 0) + 1 : 1;
-  return { lastCompleted: today, streak };
-}
-
 export function initHabits(elements, notifyError) {
-  async function completeHabit(habitId, habit) {
+  async function onCompleteHabit(habitId, habit) {
     try {
-      const nextState = nextHabitState(habit);
-      await applyReward(habit.reward || {}, { source: habit.title || "Habit" });
-      await habitsApi.patchById(habitId, nextState);
+      await completeHabit(habitId, habit);
     } catch (error) {
       notifyError(error, "Failed to complete habit");
     }
   }
 
-  return habitsApi.subscribe((habits) => {
+  return subscribeHabits((habits) => {
     elements.habitList.innerHTML = "";
     if (!habits) return;
 
@@ -46,7 +30,7 @@ export function initHabits(elements, notifyError) {
       const title = document.createElement("span");
       title.textContent = `${habit.title} (streak: ${habit.streak || 0})`;
       li.appendChild(title);
-      li.appendChild(buildActions([{ label: "Complete", onClick: () => completeHabit(id, habit) }]));
+      li.appendChild(buildActions([{ label: "Complete", onClick: () => onCompleteHabit(id, habit) }]));
       elements.habitList.appendChild(li);
     });
   });

--- a/src/modules/tasks.js
+++ b/src/modules/tasks.js
@@ -1,6 +1,5 @@
-import { dailyTasksApi, tasksApi } from "../core/firebase.js";
-import { applyReward } from "../core/rewardEngine.js";
-import { createTask, updateTask, deleteTask, completeTask as markTaskComplete } from "../services/taskService.js";
+import { completeDailyTask, subscribeDailyTasks } from "../services/dailyTaskService.js";
+import { createTask, updateTask, deleteTask, completeTask as markTaskComplete, subscribeTasks } from "../services/taskService.js";
 
 function buildActions(actions) {
   const wrap = document.createElement("div");
@@ -16,19 +15,6 @@ function buildActions(actions) {
 }
 
 export function initTasks(elements, notifyError) {
-  async function completeDailyTask(taskId) {
-    try {
-      const task = await dailyTasksApi.getById(taskId);
-      if (!task) return;
-      const today = new Date().toDateString();
-      if (task.lastCompleted === today) return alert("Already completed today");
-      await applyReward(task.reward || {}, { source: task.title || "Daily Task" });
-      await dailyTasksApi.patchById(taskId, { lastCompleted: today });
-    } catch (error) {
-      notifyError(error, "Failed to complete daily task");
-    }
-  }
-
   async function addTask() {
     try {
       await createTask({
@@ -61,15 +47,14 @@ export function initTasks(elements, notifyError) {
   async function completeTask(taskId, task) {
     if (task.completed) return;
     try {
-      await applyReward(task.reward || { exp: 20 }, { source: task.title || "Task" });
-      await markTaskComplete(taskId);
+      await markTaskComplete(taskId, task);
     } catch (error) {
       notifyError(error, "Failed to complete task");
     }
   }
 
   function loadDailyTasks() {
-    return dailyTasksApi.subscribe((tasks) => {
+    return subscribeDailyTasks((tasks) => {
       elements.dailyTaskList.innerHTML = "";
       if (!tasks) return;
       Object.entries(tasks).forEach(([id, task]) => {
@@ -77,14 +62,16 @@ export function initTasks(elements, notifyError) {
         const title = document.createElement("span");
         title.textContent = task.title;
         li.appendChild(title);
-        li.appendChild(buildActions([{ label: "Complete", onClick: () => completeDailyTask(id) }]));
+        li.appendChild(
+          buildActions([{ label: "Complete", onClick: () => completeDailyTask(id).catch((e) => notifyError(e, "Failed to complete daily task")) }])
+        );
         elements.dailyTaskList.appendChild(li);
       });
     });
   }
 
   function loadTasks() {
-    return tasksApi.subscribe((tasks) => {
+    return subscribeTasks((tasks) => {
       elements.taskList.innerHTML = "";
       if (!tasks) return;
 

--- a/src/services/dailyTaskService.js
+++ b/src/services/dailyTaskService.js
@@ -1,0 +1,19 @@
+import { dailyTasksApi } from "../core/firebaseService.js";
+import { recordDailyTaskCompletion } from "./progressService.js";
+
+export async function completeDailyTask(taskId) {
+  const task = await dailyTasksApi.getById(taskId);
+  if (!task) return;
+
+  const today = new Date().toDateString();
+  if (task.lastCompleted === today) {
+    throw new Error("Already completed today");
+  }
+
+  await dailyTasksApi.patchById(taskId, { lastCompleted: today });
+  recordDailyTaskCompletion(task);
+}
+
+export function subscribeDailyTasks(callback) {
+  return dailyTasksApi.subscribe(callback);
+}

--- a/src/services/focusService.js
+++ b/src/services/focusService.js
@@ -1,0 +1,43 @@
+import { focusApi } from "../core/firebaseService.js";
+import { recordFocusSessionCompletion } from "./progressService.js";
+
+export async function startFocusSession(minutes) {
+  const now = Date.now();
+  const sessionRef = await focusApi.addSession({
+    startTime: now,
+    duration: minutes,
+    status: "active",
+    endedAt: null,
+    createdAt: now
+  });
+
+  const sessionId = sessionRef.key;
+  await focusApi.setSessionState({
+    focusSessionActive: true,
+    sessionId,
+    startTime: now,
+    duration: minutes
+  });
+
+  return { sessionId, startTime: now, duration: minutes };
+}
+
+export async function finalizeFocusSession(sessionId, status) {
+  await focusApi.updateSessionById(sessionId, { status, endedAt: Date.now() });
+  await focusApi.clearSessionState();
+  if (status === "completed") {
+    recordFocusSessionCompletion({ sessionId });
+  }
+}
+
+export function subscribeFocusSessions(callback) {
+  return focusApi.subscribeSessions(callback);
+}
+
+export function getFocusSessionState() {
+  return focusApi.getSessionState();
+}
+
+export function deleteFocusSession(sessionId) {
+  return focusApi.deleteSessionById(sessionId);
+}

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -1,0 +1,25 @@
+import { habitsApi } from "../core/firebaseService.js";
+import { recordHabitCompletion } from "./progressService.js";
+
+function nextHabitState(habit) {
+  const today = new Date().toDateString();
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toDateString();
+  const last = habit.lastCompleted;
+
+  if (last === today) {
+    throw new Error("Habit already completed today");
+  }
+
+  const streak = last === yesterday ? (habit.streak || 0) + 1 : 1;
+  return { lastCompleted: today, streak };
+}
+
+export async function completeHabit(habitId, habit) {
+  const nextState = nextHabitState(habit);
+  await habitsApi.patchById(habitId, nextState);
+  recordHabitCompletion(habit);
+}
+
+export function subscribeHabits(callback) {
+  return habitsApi.subscribe(callback);
+}

--- a/src/services/progressService.js
+++ b/src/services/progressService.js
@@ -1,0 +1,17 @@
+import { ACTION_TYPES, emitActionEvent } from "../core/domainEvents.js";
+
+export function recordTaskCompletion(task) {
+  emitActionEvent({ type: ACTION_TYPES.TASK_COMPLETED, payload: { task } });
+}
+
+export function recordDailyTaskCompletion(task) {
+  emitActionEvent({ type: ACTION_TYPES.DAILY_TASK_COMPLETED, payload: { task } });
+}
+
+export function recordHabitCompletion(habit) {
+  emitActionEvent({ type: ACTION_TYPES.HABIT_COMPLETED, payload: { habit } });
+}
+
+export function recordFocusSessionCompletion(session) {
+  emitActionEvent({ type: ACTION_TYPES.FOCUS_SESSION_COMPLETED, payload: { session } });
+}

--- a/src/services/taskService.js
+++ b/src/services/taskService.js
@@ -1,5 +1,6 @@
 import { tasksApi } from "../core/firebaseService.js";
 import { requireNonEmptyText } from "../core/validation.js";
+import { recordTaskCompletion } from "./progressService.js";
 
 function formatTaskPayload({ title, description = "" }) {
   return {
@@ -30,10 +31,15 @@ export async function updateTask(taskId, updates = {}) {
   return tasksApi.updateById(taskId, payload);
 }
 
-export async function completeTask(taskId) {
-  return tasksApi.updateById(taskId, { completed: true, completedAt: Date.now() });
+export async function completeTask(taskId, task = null) {
+  await tasksApi.updateById(taskId, { completed: true, completedAt: Date.now() });
+  recordTaskCompletion(task || {});
 }
 
 export async function deleteTask(taskId) {
   return tasksApi.deleteById(taskId);
+}
+
+export function subscribeTasks(callback) {
+  return tasksApi.subscribe(callback);
 }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -1,4 +1,5 @@
 import { activityApi } from "../core/firebase.js";
+import { initRewardEngine } from "../core/rewardEngine.js";
 import { initStats } from "../modules/stats.js";
 import { initTasks } from "../modules/tasks.js";
 import { initHabits } from "../modules/habits.js";
@@ -69,6 +70,7 @@ function initActivityLog() {
 }
 
 function init() {
+  initRewardEngine({ notifyError });
   initStats(elements);
   initTasks(elements, notifyError);
   initHabits(elements, notifyError);


### PR DESCRIPTION
### Motivation
- Centralize Firebase path definitions and listener management to avoid duplicated path literals and enable clean teardown via `unsubscribeAll`.
- Move domain logic (tasks, habits, daily tasks, focus) into dedicated service modules to encapsulate state changes and side effects.
- Introduce an event-driven reward pipeline so progress events can trigger rewards and activity logging decoupled from UI modules.

### Description
- Added `src/core/schema.js` exporting `PATHS` and updated `src/core/firebaseService.js` to use `PATHS`, added `unsubscribeAll`, and updated all API helpers to reference `PATHS` instead of inline strings.
- Introduced domain/event tooling in `src/core/domainEvents.js` and `src/services/progressService.js` to emit and handle action events like `TASK_COMPLETED`, `DAILY_TASK_COMPLETED`, `HABIT_COMPLETED`, and `FOCUS_SESSION_COMPLETED`.
- Added `src/core/activityLogger.js` to centralize activity log entry creation and replaced inline activity logging with `logRewardActivity` in `src/core/rewardEngine.js`.
- Refactored `rewardEngine` to resolve event rewards and added `initRewardEngine` which subscribes to domain events and applies rewards with error handling.
- Created service modules: `dailyTaskService`, `focusService`, `habitService`, and extended `taskService` to emit progress events and provide subscriptions; these services encapsulate completion logic and call `progressService` record functions.
- Updated UI modules (`src/modules/tasks.js`, `src/modules/habits.js`, `src/modules/focus.js`) to consume the new services and removed direct Firebase/reward side effects; `src/ui/ui.js` now initializes the reward engine via `initRewardEngine`.

### Testing
- No new automated tests were added for these changes.
- Ran the project's existing unit/integration test suite and basic local smoke tests against the refactor; all tests and smoke checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1aafc3de88323b6a351b11fb9cf43)