### PR TITLE
docs: rewrite README and ARCHITECTURE documentation from codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,79 +1,286 @@
-Architecture Analysis
-This repository is a frontend-only, modular dashboard app built around a Realtime Firebase backend. It follows a layered structure:
+# Architecture
 
-UI composition/root
+## 1) Architectural Overview
+This application is a modular frontend dashboard that uses Firebase Realtime Database as its only persistence mechanism. At runtime, a single composition root (`src/ui/ui.js`) initializes all modules, starts the reward engine, and attaches Firebase subscriptions for live rendering.
 
-Feature modules
+The architecture is intentionally split between:
+- **UI modules** (DOM rendering + interaction handlers),
+- **service/use-case functions** (validated mutations),
+- **core infrastructure/domain logic** (Firebase access, event bus, reward and finance rules).
 
-Service layer (validated mutations)
+A key design decision is the **event-driven progression model**: user actions (task/habit/focus completion) emit domain events, and a dedicated reward engine subscribes to those events to mutate stats and write activity entries.
 
-Core infrastructure/domain logic
+---
 
-Minimal unit tests for pure logic
+## 2) Layered Architecture
+```text
++------------------------------------------------------------+
+| UI Layer (index.html, src/ui/ui.js)                        |
+| - Collect DOM refs                                           |
+| - Initialize modules + reward engine                         |
++-------------------------------+----------------------------+
+                                |
+                                v
++------------------------------------------------------------+
+| Feature Modules (src/modules/*.js)                          |
+| - Render Firebase data                                       |
+| - Bind button/input handlers                                 |
+| - Call services or APIs                                      |
++-------------------------------+----------------------------+
+                                |
+                                v
++------------------------------------------------------------+
+| Service Layer (src/services/*.js)                           |
+| - Validate input                                              |
+| - Shape mutation payloads/timestamps                          |
+| - Emit domain action events via progressService               |
++-------------------------------+----------------------------+
+                                |
+                +---------------+---------------+
+                |                               |
+                v                               v
++-------------------------------+     +------------------------+
+| Domain Events (core/domain...)|     | Core Firebase Infra    |
+| - In-memory action bus         |     | (core/firebaseService) |
++---------------+---------------+     | - path APIs            |
+                |                     | - onValue listeners    |
+                v                     | - transactions         |
++-------------------------------+     +------------------------+
+| Reward Engine (core/reward...)|
+| - Resolve reward by event type |
+| - Atomic stats transaction     |
+| - Activity log entries         |
++-------------------------------+
+```
 
-At runtime, index.html loads one JS entrypoint (src/ui/ui.js), which wires all feature modules and shared DOM references. The feature modules then subscribe to Firebase data and render/react to updates. Writes are mostly routed through services that enforce validation before persisting. rewardEngine/rewardLogic and financeLogic are the core domain engines.
+---
 
-High-Level Structure
-Entry/UI shell:
+## 3) Runtime Data Flow
+1. `index.html` loads `src/ui/ui.js` as an ES module entrypoint.
+2. `ui.js` resolves all required DOM nodes and calls:
+   - `initRewardEngine`
+   - `initStats`, `initTasks`, `initHabits`, `initNotes`, `initFinance`, `initFocus`
+   - activity log subscription initializer.
+3. Each feature module subscribes to Firebase data and rerenders section state when snapshots change.
+4. User actions trigger service functions (e.g., create/update/complete/delete).
+5. Services validate/normalize payloads, persist through Firebase APIs, and emit progress events when relevant.
+6. Reward engine consumes emitted events and updates `stats` via Firebase transaction.
+7. Activity logger writes reward records to `activityLog`.
+8. Stats and activity UI sections update automatically through active subscriptions.
 
-index.html defines all dashboard sections (stats, tasks, habits, focus, notes, finance, activity log) and imports src/ui/ui.js.
+---
 
-Composition root:
+## 4) Event System
+The event system is a minimal in-memory pub/sub in `src/core/domainEvents.js`:
+- `ACTION_TYPES` defines canonical action names:
+  - `TASK_COMPLETED`
+  - `DAILY_TASK_COMPLETED`
+  - `HABIT_COMPLETED`
+  - `FOCUS_SESSION_COMPLETED`
+- `emitActionEvent(event)` dispatches to all registered listeners.
+- `subscribeActionEvents(listener)` registers a listener and returns an unsubscribe callback.
 
-src/ui/ui.js collects DOM elements and initializes every feature module (stats, tasks, habits, notes, finance, focus) plus activity log subscription.
+`src/services/progressService.js` is the producer boundary that converts use-case outcomes into events. This keeps reward behavior decoupled from individual modules.
 
-Feature modules (src/modules):
+---
 
-Handle rendering + event handlers + subscriptions for each domain area (tasks, notes, habits, focus, finance, stats).
+## 5) Reward Engine Pipeline
+`src/core/rewardEngine.js` subscribes to action events and maps each event type to a reward payload and source label.
 
-Service layer (src/services):
+Behavior by event type:
+- Task completion: task-specific reward or default `{ exp: 20 }`.
+- Daily task completion: reward from daily task payload (or empty object).
+- Habit completion: reward from habit payload (or empty object).
+- Focus session completion: fixed `{ foc: 5, exp: 10 }`.
 
-Encapsulates writes and validation for tasks/notes/finance before calling Firebase APIs.
+It then executes:
+1. Resolve/normalize reward values using `applyRewardLocally(...).reward`.
+2. Execute `statsApi.transact(...)` to apply reward atomically against current stats.
+3. Log each non-zero stat delta to `activityLog` via `logRewardActivity`.
 
-Core (src/core):
+```text
+Action Completed
+   |
+   v
+progressService.record*Completion
+   |
+   v
+emitActionEvent({ type, payload })
+   |
+   v
+rewardEngine subscriber
+   |
+   +--> resolveEventReward(type, payload)
+   |
+   +--> statsApi.transact(applyRewardLocally)
+   |
+   +--> activityApi.addEntry(... per stat delta)
+   v
+Realtime listeners rerender Stats + Activity Log
+```
 
-Firebase setup and APIs (firebaseService.js), facade export (firebase.js), reward math/leveling (rewardLogic.js, rewardEngine.js), finance math, and generic validation utilities.
+---
 
-Tests:
+## 6) Firebase Integration
+Firebase is centralized in `src/core/firebaseService.js`:
+- Initializes app/database with a single config object.
+- Exposes low-level helpers: `read`, `write`, `patch`, `create`, `destroy`, `transaction`.
+- Wraps path-specific domain APIs:
+  - `statsApi`, `tasksApi`, `notesApi`, `financeApi`, `dailyTasksApi`, `habitsApi`, `focusApi`, `activityApi`.
 
-Node test runner verifies pure business logic (reward and finance calculations).
+Path constants are declared in `src/core/schema.js` (`PATHS`) to avoid string scattering.
 
-Runtime Flow (Request/Update Lifecycle)
-Read path (reactive)
-Modules subscribe to Firebase via APIs in firebaseService.js (through core/firebase.js facade).
+Subscription model:
+- Generic `subscribe(path, callback)` binds `onValue`.
+- `activeListeners` map ensures only one active handler per path, replacing previous listeners safely.
+- `unsubscribeAll()` detaches all tracked listeners.
 
-subscribe() uses onValue and tracks active handlers in a map, allowing listener replacement and cleanup per path.
+---
 
-Write path (validated)
-UI actions call service methods (e.g., create task/transaction/note).
+## 7) Service Layer Responsibilities
+Service files in `src/services` act as use-case boundaries:
+- **Validation:**
+  - `requireNonEmptyText`
+  - `requireAmount`
+  - `requireEnum`
+- **Payload shaping:** timestamps (`createdAt`, `updatedAt`, `date`, `completedAt`), default reward values.
+- **Mutation orchestration:** calls into specific Firebase APIs.
+- **Event emission:** completion-oriented use cases call `progressService` to emit domain events.
 
-Services validate input (requireNonEmptyText, requireAmount, requireEnum) and format payloads/timestamps.
+Notable per-service behavior:
+- `taskService`: create/update/complete/delete tasks, default completion reward `{ exp: 20 }`.
+- `dailyTaskService`: blocks duplicate completion by comparing `lastCompleted` with today string.
+- `habitService`: computes streak continuity based on yesterday/today completion dates.
+- `focusService`: manages both session history and singleton active-session state.
+- `financeService`: transaction validation + DB balance synchronization using domain math.
+- `noteService`: validation and CRUD for note content.
 
-Services call specific Firebase API methods (add/update/delete).
+---
 
-Reward path
-Features like tasks/habits/focus call applyReward.
+## 8) Module Responsibilities
+Feature modules in `src/modules` are primarily UI adapters:
+- **`stats.js`**: subscribes to `stats`, updates text values and progress bars.
+- **`tasks.js`**: renders daily tasks and one-off tasks, handles add/edit/delete/complete flows.
+- **`habits.js`**: renders habits with streak values and completion action.
+- **`focus.js`**: starts/cancels/restores timers, renders session list, supports delete.
+- **`notes.js`**: add/edit/delete notes and render notes ordered by latest timestamp.
+- **`finance.js`**: add/edit/delete transactions, render ordered list, compute local balance and sync it remotely.
 
-rewardEngine computes normalized reward locally, applies atomic stats transaction in Firebase, then writes activity log entries for each non-zero reward field.
+`src/ui/ui.js` is the composition root: it owns DOM element discovery and initializer sequencing.
 
-Layer Responsibilities
-UI modules: DOM operations, prompt/alert UX, attach handlers, render lists.
+---
 
-Services: contract enforcement and payload shaping.
+## 9) Domain Logic (`rewardEngine`, `financeLogic`)
+### Reward logic (`src/core/rewardLogic.js`)
+Pure functions:
+- `resolveReward(rawReward, context)` converts values to numbers and applies multiplier/skill-bonus rules.
+- `applyRewardLocally(currentStats, rawReward, context)` merges with default stats and applies stat deltas.
+- `applyLevelUps(stats)` loops while EXP exceeds level scaling threshold (`level * 100`).
 
-Core Firebase: persistence API abstraction and path ownership.
+This file is deterministic and unit-tested.
 
-Domain logic: deterministic, testable pure functions (rewardLogic, financeLogic).
+### Finance logic (`src/core/financeLogic.js`)
+`calculateBalance(transactions)` reduces transaction map into signed sum:
+- `income` adds
+- `expense` subtracts
 
-This is a clean separation for a small app: impure side effects (DOM/Firebase IO) live in modules/services, while calculations are isolated and unit-tested.
+Also deterministic and unit-tested.
 
-Notable Architectural Characteristics
-Single Firebase initialization point in firebaseService.js and a thin re-export facade in firebase.js, reducing direct dependency spread.
+---
 
-Feature-isolated modules with similar internal patterns (buildActions, subscribe+render).
+## 10) Activity Logging System
+`src/core/activityLogger.js` logs each non-zero reward component as its own row in `activityLog`.
 
-Realtime-first design: UI mirrors backend state continuously through listeners.
+For each stat delta it stores:
+- `stat`
+- `value`
+- `source`
+- `createdAt`
+- human-readable `message` (`+{value} {STAT} ({source})`)
 
-State restoration for long-running focus session via persisted focus/sessionState.
+UI rendering in `ui.js`:
+- subscribes to `activityLog`,
+- sorts by `createdAt` descending,
+- shows latest 20 entries.
 
-Potential coupling issue: UI modules sometimes directly use core Firebase APIs and sometimes services; consistency could be improved by routing all writes through services for stricter boundaries.
+---
+
+## 11) Listener Lifecycle Management
+Listener lifecycle is mostly managed in `firebaseService.subscribe`:
+- Subscribing to an already-subscribed path detaches old handler and registers new one.
+- Every subscribe returns an explicit unsubscribe closure.
+- `unsubscribeAll()` can be used for global teardown.
+
+Current behavior notes:
+- Feature initializers return unsubscribe callbacks, but `ui.js` does not aggregate/dispose them during app lifecycle teardown.
+- In browser usage (single-page static app), this is usually acceptable, but explicit teardown hooks would improve embeddability/testing.
+
+---
+
+## 12) Future extensibility
+Architecture supports straightforward extension:
+- Add a new module/service by following existing `initX + service + core API` pattern.
+- Add new action types in `ACTION_TYPES` and reward mapping in `resolveEventReward`.
+- Extend reward rules (multipliers, skill bonuses, level scaling) in one pure domain file.
+- Introduce additional projections (analytics/history) by subscribing to existing event bus or activity log.
+
+Suggested next evolutions:
+1. Introduce app-level lifecycle manager that stores and disposes all unsubscribe handlers.
+2. Move Firebase config to environment-driven injection.
+3. Add integration tests around service/event/reward orchestration.
+4. Standardize all writes through services (some modules currently read through direct API while mutating through services).
+5. Add typed entity/event contracts for safer module boundaries.
+
+---
+
+## Event Flow Diagram
+```text
+[User clicks Complete]
+        |
+        v
+[Feature Module Handler]
+        |
+        v
+[Service complete*()]
+        |
+        v
+[progressService.record*Completion]
+        |
+        v
+[domainEvents.emitActionEvent]
+        |
+        v
+[rewardEngine subscriber]
+        |
+        +--> [stats transaction]
+        |
+        +--> [activity log writes]
+        v
+[Firebase onValue listeners]
+        |
+        v
+[UI rerender]
+```
+
+## Reward Pipeline Diagram
+```text
+raw event
+  |
+  v
+resolveEventReward
+  |
+  v
+resolveReward / applyRewardLocally
+  |
+  v
+statsApi.transact(current -> next)
+  |
+  v
+applyLevelUps (inside reward logic)
+  |
+  v
+logRewardActivity (one row per non-zero stat)
+  |
+  v
+activity log + stats listeners update UI
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,115 @@
-# I-can-do
+# I-can-do Dashboard
+
+## Project overview
+I-can-do is a frontend-only life dashboard that stores and syncs data in Firebase Realtime Database. The app organizes personal activities (tasks, habits, focus sessions, notes, and finance transactions), emits domain events when progress actions are completed, and converts those events into stat/EXP rewards. The UI is composed from modular feature initializers and updates in realtime through Firebase subscriptions.
+
+## Key features
+- **Realtime stat tracking** with RPG-like attributes (`atk`, `int`, `disc`, `cre`, `end`, `foc`, `wis`), EXP, and level progression.
+- **Task systems**:
+  - One-off tasks with title/description, edit/delete, and completion reward.
+  - Daily tasks with once-per-day completion guard.
+- **Habit streak tracking** with daily completion and streak continuity logic.
+- **Focus sessions** with persisted active-session state, countdown timer, completion/cancel transitions, and reward emission on successful completion.
+- **Notes module** for quick text notes with edit/delete.
+- **Finance module** for income/expense transactions with computed and synchronized balance.
+- **Activity log** that records reward deltas (e.g., `+10 EXP`) and displays the most recent entries.
+- **Event-driven reward engine** that listens for domain action events and applies rewards atomically to stats.
+
+## Technology stack
+- **Runtime/UI:** Vanilla JavaScript (ES modules), HTML, CSS.
+- **Backend service:** Firebase Realtime Database (browser SDK imported from Google CDN).
+- **Testing:** Node.js built-in test runner (`node:test`) + `assert/strict`.
+- **Code quality tools:** ESLint + Prettier.
+
+## Project structure
+```text
+.
+├── index.html                  # UI layout and module entry script tag
+├── style.css                   # Dashboard styling
+├── src
+│   ├── ui
+│   │   └── ui.js               # Composition root: wires all modules
+│   ├── modules                 # Feature UI modules (render + user interactions)
+│   │   ├── stats.js
+│   │   ├── tasks.js
+│   │   ├── habits.js
+│   │   ├── focus.js
+│   │   ├── notes.js
+│   │   └── finance.js
+│   ├── services                # Validated mutation/use-case layer
+│   │   ├── taskService.js
+│   │   ├── dailyTaskService.js
+│   │   ├── habitService.js
+│   │   ├── focusService.js
+│   │   ├── noteService.js
+│   │   ├── financeService.js
+│   │   └── progressService.js  # Emits domain action events
+│   └── core                    # Infrastructure and domain logic
+│       ├── firebaseService.js  # Firebase init + path APIs + subscriptions
+│       ├── firebase.js         # Facade exports
+│       ├── schema.js           # Realtime DB path constants
+│       ├── domainEvents.js     # In-memory event bus
+│       ├── rewardEngine.js     # Event->reward application pipeline
+│       ├── rewardLogic.js      # Pure reward/level math
+│       ├── financeLogic.js     # Pure balance math
+│       ├── activityLogger.js   # Reward activity writer
+│       └── validation.js       # Shared validation helpers
+├── tests
+│   ├── reward.test.js          # rewardLogic unit tests
+│   └── finance.test.js         # financeLogic unit tests
+└── config                      # Tooling configs
+```
+
+## Setup instructions
+### Prerequisites
+- Node.js 18+ (for tests/lint/format commands).
+- Internet access for Firebase CDN imports at runtime.
+
+### Install dependencies
+```bash
+npm install
+```
+
+### Run the app locally
+This project does not include a dev server script. Serve the repository root with any static server so `index.html` can load ES modules.
+
+Examples:
+```bash
+npx serve .
+# or
+python -m http.server 3000
+```
+Then open `http://localhost:<port>/`.
+
+> Firebase config is hardcoded in `src/core/firebaseService.js`. For production hardening, move config to environment-specific injection.
+
+## Development workflow
+1. **Edit a feature module** in `src/modules` for UI behavior and rendering.
+2. **Use services** in `src/services` for mutations (validation + payload shaping).
+3. **Keep pure business rules** in `src/core/*Logic.js` for testability.
+4. **Emit progress events** through `progressService` when user actions complete.
+5. **Let reward engine react** to events (`initRewardEngine` subscription) rather than applying stats directly in feature code.
+6. Run checks before committing:
+   ```bash
+   npm test
+   npm run lint
+   npm run format
+   ```
+
+## Testing
+Current automated tests cover pure domain logic:
+- `tests/reward.test.js` validates reward normalization and level-up behavior.
+- `tests/finance.test.js` validates balance computation from income/expense transactions.
+
+Run:
+```bash
+npm test
+```
+
+## Future roadmap
+- Add CRUD services for currently read-only seeded modules (daily tasks/habits definitions).
+- Unify module write paths to always go through services (some modules currently subscribe directly via core APIs).
+- Add integration tests around service + event + reward pipeline behavior.
+- Introduce environment-based Firebase config handling.
+- Add listener teardown lifecycle from UI root for explicit app cleanup.
+- Add typed contracts (TypeScript or JSDoc typedefs) for events, rewards, and persisted entities.


### PR DESCRIPTION
### Motivation
- Provide a clear developer onboarding `README.md` and a detailed `ARCHITECTURE.md` that accurately reflect the repository's actual structure and runtime behavior. 
- Make the event-driven reward pipeline, Firebase integration, and service/module responsibilities explicit so new contributors can reason about where to change logic or add features.

### Description
- Rewrote `README.md` to include project title, overview, key features, technology stack, project structure, setup instructions, development workflow, testing guidance, and a future roadmap based strictly on the codebase. 
- Rewrote `ARCHITECTURE.md` to document the layered architecture, runtime data flow, in-memory event system, reward engine pipeline, Firebase integration, service and module responsibilities, activity logging, listener lifecycle management, and future extensibility, including ASCII diagrams for layered architecture, event flow, and reward pipeline. 
- Changes are documentation-only and limited to `README.md` and `ARCHITECTURE.md`; no application logic was modified.

### Testing
- Ran `npm test` and all automated tests passed (`tests/reward.test.js` and `tests/finance.test.js`), 3 tests total passed. 
- Ran `npm run lint` which failed in this environment due to missing dev dependency resolution (package install blocked by registry `403`), not due to code changes. 
- Ran `npm run format` which reported existing formatting issues across multiple files (these are pre-existing repository style warnings and were not introduced by this documentation update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1afae7fa88323857daab3e9bd617a)