### PR TITLE
Add Calendar module with realtime month view and CRUD events

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,90 +1,140 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Life RPG Dashboard</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="./style.css">
-</head>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Life RPG Dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./style.css" />
+  </head>
 
-<body>
-  <div class="dashboard">
-    <section class="card stats">
-      <h2>Character Stats</h2>
-      <div class="stats-grid">
-        <div class="stat"><span>ATK</span><strong id="atk">0</strong><div class="progress"><div id="bar-atk" class="bar"></div></div></div>
-        <div class="stat"><span>INT</span><strong id="int">0</strong><div class="progress"><div id="bar-int" class="bar"></div></div></div>
-        <div class="stat"><span>DISC</span><strong id="disc">0</strong><div class="progress"><div id="bar-disc" class="bar"></div></div></div>
-        <div class="stat"><span>CRE</span><strong id="cre">0</strong><div class="progress"><div id="bar-cre" class="bar"></div></div></div>
-        <div class="stat"><span>END</span><strong id="end">0</strong><div class="progress"><div id="bar-end" class="bar"></div></div></div>
-        <div class="stat"><span>FOC</span><strong id="foc">0</strong><div class="progress"><div id="bar-foc" class="bar"></div></div></div>
-        <div class="stat"><span>WIS</span><strong id="wis">0</strong><div class="progress"><div id="bar-wis" class="bar"></div></div></div>
-      </div>
-      <div class="level-box">
-        <div>Level: <strong id="level">1</strong></div>
-        <div>EXP: <strong id="exp">0</strong></div>
-      </div>
-    </section>
+  <body>
+    <div class="dashboard">
+      <section class="card stats">
+        <h2>Character Stats</h2>
+        <div class="stats-grid">
+          <div class="stat">
+            <span>ATK</span><strong id="atk">0</strong>
+            <div class="progress"><div id="bar-atk" class="bar"></div></div>
+          </div>
+          <div class="stat">
+            <span>INT</span><strong id="int">0</strong>
+            <div class="progress"><div id="bar-int" class="bar"></div></div>
+          </div>
+          <div class="stat">
+            <span>DISC</span><strong id="disc">0</strong>
+            <div class="progress"><div id="bar-disc" class="bar"></div></div>
+          </div>
+          <div class="stat">
+            <span>CRE</span><strong id="cre">0</strong>
+            <div class="progress"><div id="bar-cre" class="bar"></div></div>
+          </div>
+          <div class="stat">
+            <span>END</span><strong id="end">0</strong>
+            <div class="progress"><div id="bar-end" class="bar"></div></div>
+          </div>
+          <div class="stat">
+            <span>FOC</span><strong id="foc">0</strong>
+            <div class="progress"><div id="bar-foc" class="bar"></div></div>
+          </div>
+          <div class="stat">
+            <span>WIS</span><strong id="wis">0</strong>
+            <div class="progress"><div id="bar-wis" class="bar"></div></div>
+          </div>
+        </div>
+        <div class="level-box">
+          <div>Level: <strong id="level">1</strong></div>
+          <div>EXP: <strong id="exp">0</strong></div>
+        </div>
+      </section>
 
-    <section class="card daily">
-      <h2>Daily Tasks</h2>
-      <ul id="dailyTaskList"></ul>
-    </section>
+      <section class="card daily">
+        <h2>Daily Tasks</h2>
+        <ul id="dailyTaskList"></ul>
+      </section>
 
-    <section class="card tasks">
-      <h2>Tasks</h2>
-      <div class="task-input">
-        <input type="text" id="taskInput" placeholder="Task title">
-        <input type="text" id="taskDescriptionInput" placeholder="Task description">
-        <button id="addTaskBtn">Add</button>
-      </div>
-      <ul id="taskList"></ul>
-    </section>
+      <section class="card tasks">
+        <h2>Tasks</h2>
+        <div class="task-input">
+          <input type="text" id="taskInput" placeholder="Task title" />
+          <input type="text" id="taskDescriptionInput" placeholder="Task description" />
+          <button id="addTaskBtn">Add</button>
+        </div>
+        <ul id="taskList"></ul>
+      </section>
 
-    <section class="card habits">
-      <h2>Habits</h2>
-      <ul id="habitList"></ul>
-    </section>
+      <section class="card habits">
+        <h2>Habits</h2>
+        <ul id="habitList"></ul>
+      </section>
 
-    <section class="card focus">
-      <h2>Focus Session</h2>
-      <div class="focus-controls">
-        <button data-duration="90">Start 90 min</button>
-        <button data-duration="120">Start 120 min</button>
-        <button id="cancelFocusBtn" class="btn-danger">Cancel Active</button>
-      </div>
-      <div class="focus-timer" id="focusTimer">00:00</div>
-      <h3>Sessions</h3>
-      <ul id="focusSessionList"></ul>
-    </section>
+      <section class="card focus">
+        <h2>Focus Session</h2>
+        <div class="focus-controls">
+          <button data-duration="90">Start 90 min</button>
+          <button data-duration="120">Start 120 min</button>
+          <button id="cancelFocusBtn" class="btn-danger">Cancel Active</button>
+        </div>
+        <div class="focus-timer" id="focusTimer">00:00</div>
+        <h3>Sessions</h3>
+        <ul id="focusSessionList"></ul>
+      </section>
 
-    <section class="card notes">
-      <h2>Notes</h2>
-      <textarea id="noteInput" placeholder="Write quick note..."></textarea>
-      <button id="saveNoteBtn">Save</button>
-      <ul id="notesList"></ul>
-    </section>
+      <section class="card notes">
+        <h2>Notes</h2>
+        <textarea id="noteInput" placeholder="Write quick note..."></textarea>
+        <button id="saveNoteBtn">Save</button>
+        <ul id="notesList"></ul>
+      </section>
 
-    <section class="card finance">
-      <h2>Finance</h2>
-      <div class="balance">Balance: <strong id="balance">0</strong></div>
-      <div class="finance-input">
-        <input type="number" id="amountInput" placeholder="Amount">
-        <select id="typeInput">
-          <option value="income">Income</option>
-          <option value="expense">Expense</option>
-        </select>
-        <button id="addTransactionBtn">Add</button>
-      </div>
-      <ul id="transactionList"></ul>
-    </section>
+      <section class="card finance">
+        <h2>Finance</h2>
+        <div class="balance">Balance: <strong id="balance">0</strong></div>
+        <div class="finance-input">
+          <input type="number" id="amountInput" placeholder="Amount" />
+          <select id="typeInput">
+            <option value="income">Income</option>
+            <option value="expense">Expense</option>
+          </select>
+          <button id="addTransactionBtn">Add</button>
+        </div>
+        <ul id="transactionList"></ul>
+      </section>
 
-    <section class="card activity">
-      <h2>Activity Log</h2>
-      <ul id="activityLogList"></ul>
-    </section>
-  </div>
+      <section class="card calendar">
+        <h2>Calendar</h2>
+        <div class="calendar-input">
+          <input type="text" id="calendarTitleInput" placeholder="Event title" />
+          <input type="datetime-local" id="calendarStartInput" />
+          <input type="datetime-local" id="calendarEndInput" />
+          <textarea id="calendarNotesInput" placeholder="Event notes (optional)"></textarea>
+          <select id="calendarLinkTypeInput">
+            <option value="">No link</option>
+            <option value="task">Task</option>
+            <option value="focus">Focus Session</option>
+          </select>
+          <input
+            type="text"
+            id="calendarLinkIdInput"
+            placeholder="Linked task/session id (optional)"
+          />
+          <button id="addCalendarEventBtn">Create Event</button>
+        </div>
+        <div class="calendar-toolbar">
+          <button id="calendarPrevMonthBtn">◀</button>
+          <strong id="calendarMonthLabel"></strong>
+          <button id="calendarNextMonthBtn">▶</button>
+          <button id="calendarTodayBtn">Today</button>
+        </div>
+        <div class="calendar-weekdays" id="calendarWeekdays"></div>
+        <div class="calendar-grid" id="calendarGrid"></div>
+      </section>
 
-  <script type="module" src="./src/ui/ui.js"></script>
-</body>
+      <section class="card activity">
+        <h2>Activity Log</h2>
+        <ul id="activityLogList"></ul>
+      </section>
+    </div>
+
+    <script type="module" src="./src/ui/ui.js"></script>
+  </body>
 </html>

--- a/src/core/firebase.js
+++ b/src/core/firebase.js
@@ -8,5 +8,6 @@ export {
   dailyTasksApi,
   habitsApi,
   focusApi,
-  activityApi
+  activityApi,
+  calendarApi,
 } from "./firebaseService.js";

--- a/src/core/firebaseService.js
+++ b/src/core/firebaseService.js
@@ -9,7 +9,7 @@ import {
   onValue,
   off,
   remove,
-  runTransaction
+  runTransaction,
 } from "https://www.gstatic.com/firebasejs/10.7.1/firebase-database.js";
 import { PATHS } from "./schema.js";
 
@@ -20,7 +20,7 @@ const firebaseConfig = {
   projectId: "database-tracking-29f0a",
   storageBucket: "database-tracking-29f0a.firebasestorage.app",
   messagingSenderId: "360569185652",
-  appId: "1:360569185652:web:e4578b58055a72ee68f821"
+  appId: "1:360569185652:web:e4578b58055a72ee68f821",
 };
 
 const app = initializeApp(firebaseConfig);
@@ -92,7 +92,7 @@ export function getPaths() {
 export const statsApi = {
   get: () => read(PATHS.stats),
   set: (stats) => write(PATHS.stats, stats),
-  transact: (updater) => transaction(PATHS.stats, updater)
+  transact: (updater) => transaction(PATHS.stats, updater),
 };
 
 export const tasksApi = {
@@ -100,7 +100,7 @@ export const tasksApi = {
   subscribe: (callback) => subscribe(PATHS.tasks, callback),
   getById: (taskId) => read(`${PATHS.tasks}/${taskId}`),
   updateById: (taskId, value) => patch(`${PATHS.tasks}/${taskId}`, value),
-  deleteById: (taskId) => destroy(`${PATHS.tasks}/${taskId}`)
+  deleteById: (taskId) => destroy(`${PATHS.tasks}/${taskId}`),
 };
 
 export const notesApi = {
@@ -108,7 +108,7 @@ export const notesApi = {
   subscribe: (callback) => subscribe(PATHS.notes, callback),
   getById: (noteId) => read(`${PATHS.notes}/${noteId}`),
   updateById: (noteId, value) => patch(`${PATHS.notes}/${noteId}`, value),
-  deleteById: (noteId) => destroy(`${PATHS.notes}/${noteId}`)
+  deleteById: (noteId) => destroy(`${PATHS.notes}/${noteId}`),
 };
 
 export const financeApi = {
@@ -117,19 +117,19 @@ export const financeApi = {
   patchFinance: (value) => patch(PATHS.finance, value),
   getTransactionById: (txId) => read(`${PATHS.financeTransactions}/${txId}`),
   updateTransactionById: (txId, value) => patch(`${PATHS.financeTransactions}/${txId}`, value),
-  deleteTransactionById: (txId) => destroy(`${PATHS.financeTransactions}/${txId}`)
+  deleteTransactionById: (txId) => destroy(`${PATHS.financeTransactions}/${txId}`),
 };
 
 export const dailyTasksApi = {
   subscribe: (callback) => subscribe(PATHS.dailyTasks, callback),
   getById: (taskId) => read(`${PATHS.dailyTasks}/${taskId}`),
-  patchById: (taskId, value) => patch(`${PATHS.dailyTasks}/${taskId}`, value)
+  patchById: (taskId, value) => patch(`${PATHS.dailyTasks}/${taskId}`, value),
 };
 
 export const habitsApi = {
   subscribe: (callback) => subscribe(PATHS.habits, callback),
   getById: (habitId) => read(`${PATHS.habits}/${habitId}`),
-  patchById: (habitId, value) => patch(`${PATHS.habits}/${habitId}`, value)
+  patchById: (habitId, value) => patch(`${PATHS.habits}/${habitId}`, value),
 };
 
 export const focusApi = {
@@ -140,10 +140,18 @@ export const focusApi = {
   subscribeSessions: (callback) => subscribe(PATHS.focusSessions, callback),
   getSessionById: (sessionId) => read(`${PATHS.focusSessions}/${sessionId}`),
   updateSessionById: (sessionId, value) => patch(`${PATHS.focusSessions}/${sessionId}`, value),
-  deleteSessionById: (sessionId) => destroy(`${PATHS.focusSessions}/${sessionId}`)
+  deleteSessionById: (sessionId) => destroy(`${PATHS.focusSessions}/${sessionId}`),
 };
 
 export const activityApi = {
   addEntry: (entry) => create(PATHS.activityLog, entry),
-  subscribe: (callback) => subscribe(PATHS.activityLog, callback)
+  subscribe: (callback) => subscribe(PATHS.activityLog, callback),
+};
+
+export const calendarApi = {
+  addEvent: (event) => create(PATHS.calendarEvents, event),
+  subscribeEvents: (callback) => subscribe(PATHS.calendarEvents, callback),
+  getEventById: (eventId) => read(`${PATHS.calendarEvents}/${eventId}`),
+  updateEventById: (eventId, value) => patch(`${PATHS.calendarEvents}/${eventId}`, value),
+  deleteEventById: (eventId) => destroy(`${PATHS.calendarEvents}/${eventId}`),
 };

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -8,5 +8,7 @@ export const PATHS = Object.freeze({
   financeTransactions: "finance/transactions",
   focusSessionState: "focus/sessionState",
   focusSessions: "focus/sessions",
-  activityLog: "activityLog"
+  activityLog: "activityLog",
+  calendar: "calendar",
+  calendarEvents: "calendar/events",
 });

--- a/src/modules/calendar.js
+++ b/src/modules/calendar.js
@@ -1,0 +1,210 @@
+import {
+  createCalendarEvent,
+  updateCalendarEvent,
+  deleteCalendarEvent,
+  subscribeCalendarEvents,
+} from "../services/calendarService.js";
+
+const WEEK_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function formatDateTimeValue(value) {
+  const d = new Date(value);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
+}
+
+function formatTimeRange(event) {
+  const start = new Date(event.startAt);
+  const end = new Date(event.endAt);
+  const options = { hour: "2-digit", minute: "2-digit" };
+  return `${start.toLocaleTimeString([], options)}-${end.toLocaleTimeString([], options)}`;
+}
+
+function getMonthLabel(date) {
+  return date.toLocaleString([], { month: "long", year: "numeric" });
+}
+
+function toDayKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function getDaysGrid(viewDate) {
+  const year = viewDate.getFullYear();
+  const month = viewDate.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const daysInMonth = lastDay.getDate();
+
+  const cells = [];
+  const leading = firstDay.getDay();
+  for (let i = 0; i < leading; i += 1) {
+    cells.push(null);
+  }
+
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    cells.push(new Date(year, month, day));
+  }
+
+  while (cells.length % 7 !== 0) {
+    cells.push(null);
+  }
+
+  return cells;
+}
+
+export function initCalendar(elements, notifyError) {
+  let viewDate = new Date();
+  let eventsById = {};
+
+  function setMonthLabel() {
+    elements.calendarMonthLabel.textContent = getMonthLabel(viewDate);
+  }
+
+  async function handleCreateEvent() {
+    try {
+      await createCalendarEvent({
+        title: elements.calendarTitleInput.value,
+        startAt: elements.calendarStartInput.value,
+        endAt: elements.calendarEndInput.value,
+        notes: elements.calendarNotesInput.value,
+        linkType: elements.calendarLinkTypeInput.value,
+        linkId: elements.calendarLinkIdInput.value,
+      });
+
+      elements.calendarTitleInput.value = "";
+      elements.calendarNotesInput.value = "";
+      elements.calendarLinkTypeInput.value = "";
+      elements.calendarLinkIdInput.value = "";
+    } catch (error) {
+      notifyError(error, "Failed to create event");
+    }
+  }
+
+  async function handleEditEvent(eventId, event) {
+    const title = prompt("Edit event title:", event.title || "");
+    if (title === null) return;
+
+    const startAt = prompt(
+      "Edit start date/time (YYYY-MM-DDTHH:mm):",
+      formatDateTimeValue(event.startAt),
+    );
+    if (startAt === null) return;
+
+    const endAt = prompt(
+      "Edit end date/time (YYYY-MM-DDTHH:mm):",
+      formatDateTimeValue(event.endAt),
+    );
+    if (endAt === null) return;
+
+    const notes = prompt("Edit notes:", event.notes || "");
+    if (notes === null) return;
+
+    const linkType = prompt("Link type (task/focus or leave blank):", event.linkType || "");
+    if (linkType === null) return;
+
+    const linkId = prompt("Link id (optional):", event.linkId || "");
+    if (linkId === null) return;
+
+    try {
+      await updateCalendarEvent(eventId, { title, startAt, endAt, notes, linkType, linkId });
+    } catch (error) {
+      notifyError(error, "Failed to update event");
+    }
+  }
+
+  function render() {
+    setMonthLabel();
+    elements.calendarWeekdays.innerHTML = "";
+    WEEK_DAYS.forEach((day) => {
+      const header = document.createElement("div");
+      header.className = "calendar-weekday";
+      header.textContent = day;
+      elements.calendarWeekdays.appendChild(header);
+    });
+
+    const month = viewDate.getMonth();
+    const year = viewDate.getFullYear();
+    const monthEvents = Object.entries(eventsById || {})
+      .map(([id, event]) => ({ id, ...event }))
+      .filter((event) => {
+        const start = new Date(event.startAt || 0);
+        return start.getMonth() === month && start.getFullYear() === year;
+      })
+      .sort((a, b) => (a.startAt || 0) - (b.startAt || 0));
+
+    const byDay = new Map();
+    monthEvents.forEach((event) => {
+      const key = toDayKey(new Date(event.startAt));
+      if (!byDay.has(key)) byDay.set(key, []);
+      byDay.get(key).push(event);
+    });
+
+    elements.calendarGrid.innerHTML = "";
+    getDaysGrid(viewDate).forEach((dayDate) => {
+      const cell = document.createElement("div");
+      cell.className = "calendar-day";
+
+      if (!dayDate) {
+        cell.classList.add("is-empty");
+        elements.calendarGrid.appendChild(cell);
+        return;
+      }
+
+      const key = toDayKey(dayDate);
+      const dayLabel = document.createElement("div");
+      dayLabel.className = "calendar-day-label";
+      dayLabel.textContent = String(dayDate.getDate());
+      cell.appendChild(dayLabel);
+
+      (byDay.get(key) || []).forEach((event) => {
+        const row = document.createElement("div");
+        row.className = "calendar-event";
+
+        const text = document.createElement("button");
+        text.className = "calendar-event-btn";
+        const linkBadge = event.linkType ? ` [${event.linkType}]` : "";
+        text.textContent = `${formatTimeRange(event)} ${event.title}${linkBadge}`;
+        text.addEventListener("click", () => handleEditEvent(event.id, event));
+
+        const removeBtn = document.createElement("button");
+        removeBtn.className = "btn-danger";
+        removeBtn.textContent = "X";
+        removeBtn.addEventListener("click", () =>
+          deleteCalendarEvent(event.id).catch((e) => notifyError(e, "Failed to delete event")),
+        );
+
+        row.appendChild(text);
+        row.appendChild(removeBtn);
+        cell.appendChild(row);
+      });
+
+      elements.calendarGrid.appendChild(cell);
+    });
+  }
+
+  elements.addCalendarEventBtn.addEventListener("click", handleCreateEvent);
+  elements.calendarPrevMonthBtn.addEventListener("click", () => {
+    viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth() - 1, 1);
+    render();
+  });
+  elements.calendarNextMonthBtn.addEventListener("click", () => {
+    viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 1);
+    render();
+  });
+  elements.calendarTodayBtn.addEventListener("click", () => {
+    viewDate = new Date();
+    render();
+  });
+
+  const unsubscribe = subscribeCalendarEvents((events) => {
+    eventsById = events || {};
+    render();
+  });
+
+  render();
+  return unsubscribe;
+}

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -1,0 +1,88 @@
+import { calendarApi } from "../core/firebaseService.js";
+import { requireNonEmptyText, requireEnum } from "../core/validation.js";
+
+function toTimestamp(value, fieldName) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${fieldName} must be a valid date/time.`);
+  }
+  return timestamp;
+}
+
+function normalizeLinkType(value) {
+  if (value === undefined || value === null || value === "") return null;
+  return requireEnum(value, ["task", "focus"], "Link type");
+}
+
+function buildEventPayload({ title, startAt, endAt, notes = "", linkType = null, linkId = "" }) {
+  const normalizedStartAt = toTimestamp(startAt, "Start time");
+  const normalizedEndAt = toTimestamp(endAt, "End time");
+
+  if (normalizedEndAt <= normalizedStartAt) {
+    throw new Error("End time must be after start time.");
+  }
+
+  return {
+    title: requireNonEmptyText(title, "Event title", { maxLength: 120 }),
+    startAt: normalizedStartAt,
+    endAt: normalizedEndAt,
+    notes: String(notes || "").trim(),
+    linkType: normalizeLinkType(linkType),
+    linkId: String(linkId || "").trim() || null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+export async function createCalendarEvent(input) {
+  return calendarApi.addEvent(buildEventPayload(input));
+}
+
+export async function updateCalendarEvent(eventId, updates = {}) {
+  const payload = { updatedAt: Date.now() };
+
+  if (updates.title !== undefined) {
+    payload.title = requireNonEmptyText(updates.title, "Event title", { maxLength: 120 });
+  }
+
+  const hasStart = updates.startAt !== undefined;
+  const hasEnd = updates.endAt !== undefined;
+
+  if (hasStart) {
+    payload.startAt = toTimestamp(updates.startAt, "Start time");
+  }
+
+  if (hasEnd) {
+    payload.endAt = toTimestamp(updates.endAt, "End time");
+  }
+
+  if (
+    payload.startAt !== undefined &&
+    payload.endAt !== undefined &&
+    payload.endAt <= payload.startAt
+  ) {
+    throw new Error("End time must be after start time.");
+  }
+
+  if (updates.notes !== undefined) {
+    payload.notes = String(updates.notes || "").trim();
+  }
+
+  if (updates.linkType !== undefined) {
+    payload.linkType = normalizeLinkType(updates.linkType);
+  }
+
+  if (updates.linkId !== undefined) {
+    payload.linkId = String(updates.linkId || "").trim() || null;
+  }
+
+  return calendarApi.updateEventById(eventId, payload);
+}
+
+export async function deleteCalendarEvent(eventId) {
+  return calendarApi.deleteEventById(eventId);
+}
+
+export function subscribeCalendarEvents(callback) {
+  return calendarApi.subscribeEvents(callback);
+}

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -6,6 +6,7 @@ import { initHabits } from "../modules/habits.js";
 import { initNotes } from "../modules/notes.js";
 import { initFinance } from "../modules/finance.js";
 import { initFocus } from "../modules/focus.js";
+import { initCalendar } from "../modules/calendar.js";
 
 const elements = {
   atk: document.getElementById("atk"),
@@ -24,7 +25,7 @@ const elements = {
     cre: document.getElementById("bar-cre"),
     end: document.getElementById("bar-end"),
     foc: document.getElementById("bar-foc"),
-    wis: document.getElementById("bar-wis")
+    wis: document.getElementById("bar-wis"),
   },
   dailyTaskList: document.getElementById("dailyTaskList"),
   taskInput: document.getElementById("taskInput"),
@@ -44,7 +45,20 @@ const elements = {
   addTransactionBtn: document.getElementById("addTransactionBtn"),
   transactionList: document.getElementById("transactionList"),
   balance: document.getElementById("balance"),
-  activityLogList: document.getElementById("activityLogList")
+  activityLogList: document.getElementById("activityLogList"),
+  calendarTitleInput: document.getElementById("calendarTitleInput"),
+  calendarStartInput: document.getElementById("calendarStartInput"),
+  calendarEndInput: document.getElementById("calendarEndInput"),
+  calendarNotesInput: document.getElementById("calendarNotesInput"),
+  calendarLinkTypeInput: document.getElementById("calendarLinkTypeInput"),
+  calendarLinkIdInput: document.getElementById("calendarLinkIdInput"),
+  addCalendarEventBtn: document.getElementById("addCalendarEventBtn"),
+  calendarPrevMonthBtn: document.getElementById("calendarPrevMonthBtn"),
+  calendarNextMonthBtn: document.getElementById("calendarNextMonthBtn"),
+  calendarTodayBtn: document.getElementById("calendarTodayBtn"),
+  calendarMonthLabel: document.getElementById("calendarMonthLabel"),
+  calendarWeekdays: document.getElementById("calendarWeekdays"),
+  calendarGrid: document.getElementById("calendarGrid"),
 };
 
 function notifyError(error, fallback = "Operation failed") {
@@ -63,7 +77,8 @@ function initActivityLog() {
       .slice(0, 20)
       .forEach((entry) => {
         const li = document.createElement("li");
-        li.textContent = entry.message || `+${entry.value} ${String(entry.stat || "").toUpperCase()}`;
+        li.textContent =
+          entry.message || `+${entry.value} ${String(entry.stat || "").toUpperCase()}`;
         elements.activityLogList.appendChild(li);
       });
   });
@@ -77,6 +92,7 @@ function init() {
   initNotes(elements, notifyError);
   initFinance(elements, notifyError);
   initFocus(elements, notifyError);
+  initCalendar(elements, notifyError);
   initActivityLog();
 }
 

--- a/style.css
+++ b/style.css
@@ -9,7 +9,9 @@
   --border: #1f2937;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
@@ -32,10 +34,20 @@ body {
   padding: 14px;
 }
 
-h2, h3 { margin: 0 0 10px; }
-h3 { font-size: 14px; color: var(--muted); }
+h2,
+h3 {
+  margin: 0 0 10px;
+}
+h3 {
+  font-size: 14px;
+  color: var(--muted);
+}
 
-ul { list-style: none; margin: 0; padding: 0; }
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 
 li {
   margin-bottom: 10px;
@@ -45,7 +57,10 @@ li {
   padding: 8px;
 }
 
-input, select, textarea, button {
+input,
+select,
+textarea,
+button {
   width: 100%;
   margin-top: 8px;
   padding: 8px;
@@ -60,11 +75,21 @@ button {
   cursor: pointer;
 }
 
-.btn-danger { background: var(--danger); }
-.btn-muted { background: #475569; }
+.btn-danger {
+  background: var(--danger);
+}
+.btn-muted {
+  background: #475569;
+}
 
-.item-main { margin-bottom: 8px; color: var(--text); }
-.is-completed { text-decoration: line-through; opacity: 0.7; }
+.item-main {
+  margin-bottom: 8px;
+  color: var(--text);
+}
+.is-completed {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
 
 .item-actions {
   display: flex;
@@ -77,8 +102,14 @@ button {
   font-size: 12px;
 }
 
-.focus-controls { display: flex; gap: 8px; flex-wrap: wrap; }
-.focus-controls button { width: auto; }
+.focus-controls {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.focus-controls button {
+  width: auto;
+}
 
 .stats-grid {
   display: grid;
@@ -86,7 +117,10 @@ button {
   gap: 10px;
 }
 
-.stat strong { display: block; margin: 4px 0; }
+.stat strong {
+  display: block;
+  margin: 4px 0;
+}
 
 .progress {
   height: 8px;
@@ -112,4 +146,73 @@ button {
   margin: 10px 0;
   font-size: 28px;
   font-weight: bold;
+}
+
+.calendar-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0;
+}
+
+.calendar-toolbar strong {
+  flex: 1;
+  text-align: center;
+}
+
+.calendar-toolbar button {
+  width: auto;
+  margin-top: 0;
+}
+
+.calendar-weekdays,
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.calendar-weekday {
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.calendar-day {
+  min-height: 100px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px;
+  overflow: hidden;
+}
+
+.calendar-day.is-empty {
+  opacity: 0.4;
+}
+
+.calendar-day-label {
+  font-size: 12px;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+
+.calendar-event {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.calendar-event-btn {
+  flex: 1;
+  margin-top: 0;
+  padding: 4px 6px;
+  font-size: 11px;
+  text-align: left;
+  background: #334155;
+}
+
+.calendar-event .btn-danger {
+  width: auto;
+  margin-top: 0;
+  padding: 4px 6px;
 }


### PR DESCRIPTION
### Motivation

- Provide a first-class calendar feature to schedule time-block events and keep them synced in realtime through Firebase.
- Ensure all calendar mutations go through the service/use-case layer for validation and consistent payload shaping like other modules.
- Keep UI code focused on rendering and event handlers while integrating events with existing domains (tasks, focus sessions) via optional links.

### Description

- Add a validated service layer: `src/services/calendarService.js` implements `createCalendarEvent`, `updateCalendarEvent`, `deleteCalendarEvent`, and `subscribeCalendarEvents` with date validation and normalized payloads.
- Add UI module: `src/modules/calendar.js` provides a month-grid view, previous/next/today navigation, event creation form, prompt-based editing, deletion, and subscribes to `calendar/events` for realtime updates.
- Extend core Firebase APIs and schema: `src/core/schema.js` adds `calendar`/`calendarEvents` paths and `src/core/firebaseService.js` exposes a `calendarApi`; `src/core/firebase.js` re-exports it for use by modules/services.
- Integrate into app: wire `initCalendar` into the composition root (`src/ui/ui.js`), add calendar markup in `index.html`, and styles in `style.css` following project conventions; events support optional `linkType` (`task`/`focus`) and `linkId`.

### Testing

- Ran `npm test` (unit tests): all tests passed (`tests/*.test.js` all green).
- Ran `npm run lint`: linter exited successfully with no new errors reported for the changes.
- Ran `npm run format:write` to apply formatting and `npm run format` (check): repository contains unrelated pre-existing formatting warnings so `--check` reported those existing issues (formatting of new files was applied with `format:write`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b53061148323a155c1f63a8b43ac)