### PR TITLE
Refactor UI into sidebar/main/task three-panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,131 +8,183 @@
   </head>
 
   <body>
-    <div class="dashboard">
-      <section class="card stats">
-        <h2>Character Stats</h2>
-        <div class="stats-grid">
-          <div class="stat">
-            <span>ATK</span><strong id="atk">0</strong>
-            <div class="progress"><div id="bar-atk" class="bar"></div></div>
+    <div class="app-layout">
+      <aside class="sidebar card">
+        <h2>Navigate</h2>
+        <nav class="sidebar-nav" id="sidebarNav">
+          <button class="nav-btn is-active" data-view="dashboard" title="Dashboard">🏠</button>
+          <button class="nav-btn" data-view="calendar" title="Calendar">📅</button>
+          <button class="nav-btn" data-view="focus" title="Focus">🎯</button>
+          <button class="nav-btn" data-view="notes" title="Notes">📝</button>
+          <button class="nav-btn" data-view="finance" title="Finance">💰</button>
+          <button class="nav-btn" data-view="stats" title="Stats">📊</button>
+        </nav>
+      </aside>
+
+      <main class="main-area">
+        <section class="main-view is-active" data-view="dashboard">
+          <section class="card">
+            <h2>Today Summary</h2>
+            <ul id="todaySummaryList"></ul>
+          </section>
+
+          <section class="card">
+            <h2>Today's Calendar Events</h2>
+            <ul id="todayEventsList"></ul>
+          </section>
+
+          <section class="card activity">
+            <h2>Recent Activity Log</h2>
+            <ul id="activityLogList"></ul>
+          </section>
+
+          <section class="card">
+            <h2>Quick Stat Overview</h2>
+            <div class="quick-stats-grid">
+              <div><span>ATK</span><strong id="quick-atk">0</strong></div>
+              <div><span>INT</span><strong id="quick-int">0</strong></div>
+              <div><span>DISC</span><strong id="quick-disc">0</strong></div>
+              <div><span>CRE</span><strong id="quick-cre">0</strong></div>
+              <div><span>END</span><strong id="quick-end">0</strong></div>
+              <div><span>FOC</span><strong id="quick-foc">0</strong></div>
+              <div><span>WIS</span><strong id="quick-wis">0</strong></div>
+              <div><span>LVL / EXP</span><strong id="quick-level-exp">1 / 0</strong></div>
+            </div>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="calendar">
+          <section class="card calendar">
+            <h2>Calendar</h2>
+            <div class="calendar-input">
+              <input type="text" id="calendarTitleInput" placeholder="Event title" />
+              <input type="datetime-local" id="calendarStartInput" />
+              <input type="datetime-local" id="calendarEndInput" />
+              <textarea id="calendarNotesInput" placeholder="Event notes (optional)"></textarea>
+              <select id="calendarLinkTypeInput">
+                <option value="">No link</option>
+                <option value="task">Task</option>
+                <option value="focus">Focus Session</option>
+              </select>
+              <input
+                type="text"
+                id="calendarLinkIdInput"
+                placeholder="Linked task/session id (optional)"
+              />
+              <button id="addCalendarEventBtn">Create Event</button>
+            </div>
+            <div class="calendar-toolbar">
+              <button id="calendarPrevMonthBtn">◀</button>
+              <strong id="calendarMonthLabel"></strong>
+              <button id="calendarNextMonthBtn">▶</button>
+              <button id="calendarTodayBtn">Today</button>
+            </div>
+            <div class="calendar-weekdays" id="calendarWeekdays"></div>
+            <div class="calendar-grid" id="calendarGrid"></div>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="focus">
+          <section class="card focus">
+            <h2>Focus Session</h2>
+            <div class="focus-controls">
+              <button data-duration="90">Start 90 min</button>
+              <button data-duration="120">Start 120 min</button>
+              <button id="cancelFocusBtn" class="btn-danger">Cancel Active</button>
+            </div>
+            <div class="focus-timer" id="focusTimer">00:00</div>
+            <h3>Sessions</h3>
+            <ul id="focusSessionList"></ul>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="notes">
+          <section class="card notes">
+            <h2>Notes</h2>
+            <textarea id="noteInput" placeholder="Write quick note..."></textarea>
+            <button id="saveNoteBtn">Save</button>
+            <ul id="notesList"></ul>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="finance">
+          <section class="card finance">
+            <h2>Finance</h2>
+            <div class="balance">Balance: <strong id="balance">0</strong></div>
+            <div class="finance-input">
+              <input type="number" id="amountInput" placeholder="Amount" />
+              <select id="typeInput">
+                <option value="income">Income</option>
+                <option value="expense">Expense</option>
+              </select>
+              <button id="addTransactionBtn">Add</button>
+            </div>
+            <ul id="transactionList"></ul>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="stats">
+          <section class="card stats">
+            <h2>Character Stats</h2>
+            <div class="stats-grid">
+              <div class="stat">
+                <span>ATK</span><strong id="atk">0</strong>
+                <div class="progress"><div id="bar-atk" class="bar"></div></div>
+              </div>
+              <div class="stat">
+                <span>INT</span><strong id="int">0</strong>
+                <div class="progress"><div id="bar-int" class="bar"></div></div>
+              </div>
+              <div class="stat">
+                <span>DISC</span><strong id="disc">0</strong>
+                <div class="progress"><div id="bar-disc" class="bar"></div></div>
+              </div>
+              <div class="stat">
+                <span>CRE</span><strong id="cre">0</strong>
+                <div class="progress"><div id="bar-cre" class="bar"></div></div>
+              </div>
+              <div class="stat">
+                <span>END</span><strong id="end">0</strong>
+                <div class="progress"><div id="bar-end" class="bar"></div></div>
+              </div>
+              <div class="stat">
+                <span>FOC</span><strong id="foc">0</strong>
+                <div class="progress"><div id="bar-foc" class="bar"></div></div>
+              </div>
+              <div class="stat">
+                <span>WIS</span><strong id="wis">0</strong>
+                <div class="progress"><div id="bar-wis" class="bar"></div></div>
+              </div>
+            </div>
+            <div class="level-box">
+              <div>Level: <strong id="level">1</strong></div>
+              <div>EXP: <strong id="exp">0</strong></div>
+            </div>
+          </section>
+        </section>
+      </main>
+
+      <aside class="task-panel">
+        <section class="card daily">
+          <h2>Daily Tasks</h2>
+          <ul id="dailyTaskList"></ul>
+        </section>
+
+        <section class="card tasks">
+          <h2>Tasks</h2>
+          <div class="task-input">
+            <input type="text" id="taskInput" placeholder="Task title" />
+            <input type="text" id="taskDescriptionInput" placeholder="Task description" />
+            <button id="addTaskBtn">Add</button>
           </div>
-          <div class="stat">
-            <span>INT</span><strong id="int">0</strong>
-            <div class="progress"><div id="bar-int" class="bar"></div></div>
-          </div>
-          <div class="stat">
-            <span>DISC</span><strong id="disc">0</strong>
-            <div class="progress"><div id="bar-disc" class="bar"></div></div>
-          </div>
-          <div class="stat">
-            <span>CRE</span><strong id="cre">0</strong>
-            <div class="progress"><div id="bar-cre" class="bar"></div></div>
-          </div>
-          <div class="stat">
-            <span>END</span><strong id="end">0</strong>
-            <div class="progress"><div id="bar-end" class="bar"></div></div>
-          </div>
-          <div class="stat">
-            <span>FOC</span><strong id="foc">0</strong>
-            <div class="progress"><div id="bar-foc" class="bar"></div></div>
-          </div>
-          <div class="stat">
-            <span>WIS</span><strong id="wis">0</strong>
-            <div class="progress"><div id="bar-wis" class="bar"></div></div>
-          </div>
-        </div>
-        <div class="level-box">
-          <div>Level: <strong id="level">1</strong></div>
-          <div>EXP: <strong id="exp">0</strong></div>
-        </div>
-      </section>
+          <ul id="taskList"></ul>
+        </section>
 
-      <section class="card daily">
-        <h2>Daily Tasks</h2>
-        <ul id="dailyTaskList"></ul>
-      </section>
-
-      <section class="card tasks">
-        <h2>Tasks</h2>
-        <div class="task-input">
-          <input type="text" id="taskInput" placeholder="Task title" />
-          <input type="text" id="taskDescriptionInput" placeholder="Task description" />
-          <button id="addTaskBtn">Add</button>
-        </div>
-        <ul id="taskList"></ul>
-      </section>
-
-      <section class="card habits">
-        <h2>Habits</h2>
-        <ul id="habitList"></ul>
-      </section>
-
-      <section class="card focus">
-        <h2>Focus Session</h2>
-        <div class="focus-controls">
-          <button data-duration="90">Start 90 min</button>
-          <button data-duration="120">Start 120 min</button>
-          <button id="cancelFocusBtn" class="btn-danger">Cancel Active</button>
-        </div>
-        <div class="focus-timer" id="focusTimer">00:00</div>
-        <h3>Sessions</h3>
-        <ul id="focusSessionList"></ul>
-      </section>
-
-      <section class="card notes">
-        <h2>Notes</h2>
-        <textarea id="noteInput" placeholder="Write quick note..."></textarea>
-        <button id="saveNoteBtn">Save</button>
-        <ul id="notesList"></ul>
-      </section>
-
-      <section class="card finance">
-        <h2>Finance</h2>
-        <div class="balance">Balance: <strong id="balance">0</strong></div>
-        <div class="finance-input">
-          <input type="number" id="amountInput" placeholder="Amount" />
-          <select id="typeInput">
-            <option value="income">Income</option>
-            <option value="expense">Expense</option>
-          </select>
-          <button id="addTransactionBtn">Add</button>
-        </div>
-        <ul id="transactionList"></ul>
-      </section>
-
-      <section class="card calendar">
-        <h2>Calendar</h2>
-        <div class="calendar-input">
-          <input type="text" id="calendarTitleInput" placeholder="Event title" />
-          <input type="datetime-local" id="calendarStartInput" />
-          <input type="datetime-local" id="calendarEndInput" />
-          <textarea id="calendarNotesInput" placeholder="Event notes (optional)"></textarea>
-          <select id="calendarLinkTypeInput">
-            <option value="">No link</option>
-            <option value="task">Task</option>
-            <option value="focus">Focus Session</option>
-          </select>
-          <input
-            type="text"
-            id="calendarLinkIdInput"
-            placeholder="Linked task/session id (optional)"
-          />
-          <button id="addCalendarEventBtn">Create Event</button>
-        </div>
-        <div class="calendar-toolbar">
-          <button id="calendarPrevMonthBtn">◀</button>
-          <strong id="calendarMonthLabel"></strong>
-          <button id="calendarNextMonthBtn">▶</button>
-          <button id="calendarTodayBtn">Today</button>
-        </div>
-        <div class="calendar-weekdays" id="calendarWeekdays"></div>
-        <div class="calendar-grid" id="calendarGrid"></div>
-      </section>
-
-      <section class="card activity">
-        <h2>Activity Log</h2>
-        <ul id="activityLogList"></ul>
-      </section>
+        <section class="card habits">
+          <h2>Habits</h2>
+          <ul id="habitList"></ul>
+        </section>
+      </aside>
     </div>
 
     <script type="module" src="./src/ui/ui.js"></script>

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -27,6 +27,21 @@ const elements = {
     foc: document.getElementById("bar-foc"),
     wis: document.getElementById("bar-wis"),
   },
+  quickStats: {
+    atk: document.getElementById("quick-atk"),
+    int: document.getElementById("quick-int"),
+    disc: document.getElementById("quick-disc"),
+    cre: document.getElementById("quick-cre"),
+    end: document.getElementById("quick-end"),
+    foc: document.getElementById("quick-foc"),
+    wis: document.getElementById("quick-wis"),
+    levelExp: document.getElementById("quick-level-exp"),
+  },
+  todaySummaryList: document.getElementById("todaySummaryList"),
+  todayEventsList: document.getElementById("todayEventsList"),
+  sidebarNav: document.getElementById("sidebarNav"),
+  navButtons: document.querySelectorAll(".nav-btn"),
+  mainViews: document.querySelectorAll(".main-view"),
   dailyTaskList: document.getElementById("dailyTaskList"),
   taskInput: document.getElementById("taskInput"),
   taskDescriptionInput: document.getElementById("taskDescriptionInput"),
@@ -67,6 +82,112 @@ function notifyError(error, fallback = "Operation failed") {
   alert(message);
 }
 
+function switchMainView(viewName) {
+  elements.mainViews.forEach((view) => {
+    view.classList.toggle("is-active", view.dataset.view === viewName);
+  });
+
+  elements.navButtons.forEach((button) => {
+    button.classList.toggle("is-active", button.dataset.view === viewName);
+  });
+}
+
+function initNavigation() {
+  elements.sidebarNav.addEventListener("click", (event) => {
+    const button = event.target.closest(".nav-btn");
+    if (!button) return;
+    switchMainView(button.dataset.view);
+  });
+}
+
+function mirrorQuickStats() {
+  const statKeys = ["atk", "int", "disc", "cre", "end", "foc", "wis"];
+  statKeys.forEach((key) => {
+    elements.quickStats[key].textContent = elements[key].textContent;
+  });
+  elements.quickStats.levelExp.textContent = `${elements.level.textContent} / ${elements.exp.textContent}`;
+}
+
+function renderTodaySummary() {
+  const rows = [
+    `Daily tasks: ${elements.dailyTaskList.children.length}`,
+    `Open tasks: ${elements.taskList.querySelectorAll(".item-main:not(.is-completed)").length}`,
+    `Completed tasks: ${elements.taskList.querySelectorAll(".item-main.is-completed").length}`,
+    `Habits tracked: ${elements.habitList.children.length}`,
+    `Focus sessions: ${elements.focusSessionList.children.length}`,
+  ];
+
+  elements.todaySummaryList.innerHTML = "";
+  rows.forEach((row) => {
+    const li = document.createElement("li");
+    li.textContent = row;
+    elements.todaySummaryList.appendChild(li);
+  });
+}
+
+function renderTodayEvents() {
+  const day = new Date().getDate();
+  const calendarDayLabel = Array.from(elements.calendarGrid.querySelectorAll(".calendar-day-label")).find(
+    (label) => Number(label.textContent) === day,
+  );
+
+  elements.todayEventsList.innerHTML = "";
+
+  if (!calendarDayLabel) {
+    const li = document.createElement("li");
+    li.textContent = "No events scheduled for today.";
+    elements.todayEventsList.appendChild(li);
+    return;
+  }
+
+  const dayCell = calendarDayLabel.closest(".calendar-day");
+  const eventButtons = dayCell ? dayCell.querySelectorAll(".calendar-event-btn") : [];
+
+  if (!eventButtons.length) {
+    const li = document.createElement("li");
+    li.textContent = "No events scheduled for today.";
+    elements.todayEventsList.appendChild(li);
+    return;
+  }
+
+  eventButtons.forEach((button) => {
+    const li = document.createElement("li");
+    li.textContent = button.textContent;
+    elements.todayEventsList.appendChild(li);
+  });
+}
+
+function observeDashboardData() {
+  const observer = new MutationObserver(() => {
+    mirrorQuickStats();
+    renderTodaySummary();
+    renderTodayEvents();
+  });
+
+  [
+    elements.dailyTaskList,
+    elements.taskList,
+    elements.habitList,
+    elements.focusSessionList,
+    elements.calendarGrid,
+    elements.level,
+    elements.exp,
+    elements.atk,
+    elements.int,
+    elements.disc,
+    elements.cre,
+    elements.end,
+    elements.foc,
+    elements.wis,
+  ].forEach((target) => {
+    observer.observe(target, { childList: true, subtree: true, characterData: true });
+  });
+
+  mirrorQuickStats();
+  renderTodaySummary();
+  renderTodayEvents();
+}
+
 function initActivityLog() {
   return activityApi.subscribe((entries) => {
     elements.activityLogList.innerHTML = "";
@@ -85,6 +206,7 @@ function initActivityLog() {
 }
 
 function init() {
+  initNavigation();
   initRewardEngine({ notifyError });
   initStats(elements);
   initTasks(elements, notifyError);
@@ -94,6 +216,7 @@ function init() {
   initFocus(elements, notifyError);
   initCalendar(elements, notifyError);
   initActivityLog();
+  observeDashboardData();
 }
 
 init();

--- a/style.css
+++ b/style.css
@@ -20,11 +20,12 @@ body {
   color: var(--text);
 }
 
-.dashboard {
+.app-layout {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: 88px minmax(0, 1fr) minmax(320px, 360px);
   gap: 16px;
   padding: 16px;
+  min-height: 100vh;
 }
 
 .card {
@@ -34,10 +35,67 @@ body {
   padding: 14px;
 }
 
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+}
+
+.sidebar h2 {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0;
+}
+
+.sidebar-nav {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav-btn {
+  font-size: 20px;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0b1220;
+}
+
+.nav-btn.is-active {
+  background: var(--accent-2);
+}
+
+.main-area,
+.task-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.main-view {
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.main-view.is-active {
+  display: flex;
+}
+
+.task-panel {
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
 h2,
 h3 {
   margin: 0 0 10px;
 }
+
 h3 {
   font-size: 14px;
   color: var(--muted);
@@ -78,6 +136,7 @@ button {
 .btn-danger {
   background: var(--danger);
 }
+
 .btn-muted {
   background: #475569;
 }
@@ -86,6 +145,7 @@ button {
   margin-bottom: 8px;
   color: var(--text);
 }
+
 .is-completed {
   text-decoration: line-through;
   opacity: 0.7;
@@ -95,6 +155,7 @@ button {
   display: flex;
   gap: 6px;
 }
+
 .item-actions button {
   width: auto;
   margin-top: 0;
@@ -107,6 +168,7 @@ button {
   gap: 8px;
   flex-wrap: wrap;
 }
+
 .focus-controls button {
   width: auto;
 }
@@ -115,6 +177,28 @@ button {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
+}
+
+.quick-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.quick-stats-grid div {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.quick-stats-grid span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.quick-stats-grid strong {
+  display: block;
+  margin-top: 4px;
 }
 
 .stat strong {
@@ -215,4 +299,34 @@ button {
   width: auto;
   margin-top: 0;
   padding: 4px 6px;
+}
+
+@media (max-width: 1200px) {
+  .app-layout {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .task-panel {
+    grid-column: 1 / -1;
+    max-height: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    align-items: stretch;
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .nav-btn {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
### Motivation
- Restructure the interface into a 3-panel workspace to separate navigation, primary views, and persistent task tracking while reusing existing modules and IDs. 
- Keep existing module logic and architecture boundaries intact so UI changes do not introduce backend or domain logic changes.

### Description
- Reworked `index.html` into a three-column shell with a left icon sidebar (`dashboard`, `calendar`, `focus`, `notes`, `finance`, `stats`), a central switchable main area (multiple `main-view` sections), and a persistent right `task-panel` containing `Daily Tasks`, `Tasks`, and `Habits` (reusing original DOM IDs). 
- Updated `style.css` to implement the three-column responsive grid, sidebar nav button styles and active state, show/hide behavior for `main-view` sections, and responsive fallbacks for narrower screens. 
- Updated `src/ui/ui.js` to initialize the original modules unchanged and add lightweight UI wiring: in-page view switching (no reload) via `switchMainView`/`initNavigation`, and dashboard summary sync (quick stats, today summary, today events) via a `MutationObserver` so existing module subscriptions remain functional. 
- No module business logic or core Firebase code was modified; all changes are layout/initialization-only and reuse existing services and APIs.

### Testing
- Ran unit tests with `npm test` and all tests passed (3/3). 
- Ran linter with `npm run lint` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2261bd6d48323919bf2dff1baf253)