### PR TITLE
Unify card UI across tasks/habits/dailies and simplify calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,20 +67,20 @@
                 <h3>Task Board</h3>
                 <div class="task-columns">
                   <div class="task-column">
-                    <h4>New</h4>
-                    <ul id="kanban-new"></ul>
+                    <h4>Backlog</h4>
+                    <ul id="kanban-backlog"></ul>
+                  </div>
+                  <div class="task-column">
+                    <h4>Todo</h4>
+                    <ul id="kanban-todo"></ul>
                   </div>
                   <div class="task-column">
                     <h4>In Progress</h4>
-                    <ul id="kanban-progress"></ul>
+                    <ul id="kanban-in-progress"></ul>
                   </div>
                   <div class="task-column">
-                    <h4>Completed</h4>
+                    <h4>Done</h4>
                     <ul id="kanban-done"></ul>
-                  </div>
-                  <div class="task-column">
-                    <h4>Canceled</h4>
-                    <ul id="kanban-canceled"></ul>
                   </div>
                 </div>
               </section>
@@ -88,23 +88,6 @@
 
             <section class="calendar-mode" data-calendar-mode="timeline">
               <section class="calendar-timeline">
-                <div class="calendar-input">
-                  <input type="text" id="calendarTitleInput" placeholder="Event title" />
-                  <input type="datetime-local" id="calendarStartInput" />
-                  <input type="datetime-local" id="calendarEndInput" />
-                  <textarea id="calendarNotesInput" placeholder="Event notes (optional)"></textarea>
-                  <select id="calendarLinkTypeInput">
-                    <option value="">No link</option>
-                    <option value="task">Task</option>
-                    <option value="focus">Focus Session</option>
-                  </select>
-                  <input
-                    type="text"
-                    id="calendarLinkIdInput"
-                    placeholder="Linked task/session id (optional)"
-                  />
-                  <button id="addCalendarEventBtn">Create Event</button>
-                </div>
                 <div class="calendar-toolbar">
                   <button id="calendarPrevMonthBtn">◀</button>
                   <strong id="calendarMonthLabel"></strong>
@@ -210,32 +193,15 @@
 
         <section>
           <h3>Daily Tasks <small id="dailyProgressText">0/0 completed</small></h3>
-          <div class="sub-form">
-            <input type="text" id="dailyTaskInput" placeholder="Daily task title" />
-            <input type="time" id="dailyTaskTimeInput" />
-            <input type="text" id="dailyTaskConditionInput" placeholder="Condition" />
-            <button id="addDailyTaskBtn">Add Daily Task</button>
-          </div>
+          <button id="addDailyTaskBtn">+ Add Daily Task</button>
+          <div id="dailyTaskCreationArea"></div>
           <ul id="dailyTaskList"></ul>
         </section>
 
         <section>
           <h3>Habits</h3>
-          <div class="sub-form">
-            <input type="text" id="habitInput" placeholder="Habit title" />
-            <select id="habitDayInput">
-              <option value="1">Monday</option>
-              <option value="2">Tuesday</option>
-              <option value="3">Wednesday</option>
-              <option value="4">Thursday</option>
-              <option value="5">Friday</option>
-              <option value="6">Saturday</option>
-              <option value="0">Sunday</option>
-            </select>
-            <input type="time" id="habitTimeInput" />
-            <input type="text" id="habitConditionInput" placeholder="Condition" />
-            <button id="addHabitBtn">Add Habit</button>
-          </div>
+          <button id="addHabitBtn">+ Add Habit</button>
+          <div id="habitCreationArea"></div>
           <ul id="habitList"></ul>
         </section>
 

--- a/src/core/workItemModel.js
+++ b/src/core/workItemModel.js
@@ -1,6 +1,6 @@
 import { requireEnum, requireNonEmptyText } from "./validation.js";
 
-const STATUS_VALUES = ["new", "progress", "done", "canceled"];
+const STATUS_VALUES = ["backlog", "todo", "in_progress", "done"];
 const PRIORITY_VALUES = ["low", "medium", "high"];
 const TYPE_VALUES = ["task", "daily", "habit", "work", "personal", "study"];
 
@@ -42,12 +42,14 @@ export function createWorkItemPayload({
   description = "",
   condition = "",
 }) {
+  const resolvedType = requireEnum(type, TYPE_VALUES, "Type");
+
   return {
     title: requireNonEmptyText(title, "Title", { maxLength: 120 }),
-    type: requireEnum(type, TYPE_VALUES, "Type"),
+    type: resolvedType,
     priority: requireEnum(priority, PRIORITY_VALUES, "Priority"),
     schedule: normalizeSchedule(schedule),
-    status: "new",
+    status: resolvedType === "task" ? "backlog" : "todo",
     description: String(description || "").trim(),
     condition: String(condition || "").trim(),
     completed: false,

--- a/src/modules/calendar.js
+++ b/src/modules/calendar.js
@@ -1,22 +1,6 @@
 import { tasksApi, dailyTasksApi, habitsApi } from "../core/firebase.js";
-import {
-  createCalendarEvent,
-  updateCalendarEvent,
-  deleteCalendarEvent,
-  subscribeCalendarEvents,
-} from "../services/calendarService.js";
 
 const WEEK_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
-function formatDateTimeValue(value) {
-  const d = new Date(value);
-  const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  const hh = String(d.getHours()).padStart(2, "0");
-  const min = String(d.getMinutes()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
-}
 
 function formatTimeRange(event) {
   const start = new Date(event.startAt);
@@ -78,7 +62,7 @@ function scheduledItems(days, tasks, dailyTasks, habits) {
   const add = (dayKey, item) => {
     if (!keys.has(dayKey)) return;
     if (!byDay.has(dayKey)) byDay.set(dayKey, []);
-    byDay.get(dayKey).push(item);
+    byDay.get(dayKey).push({ ...item, readonly: true });
   };
 
   Object.entries(tasks || {}).forEach(([id, task]) => {
@@ -124,60 +108,15 @@ function scheduledItems(days, tasks, dailyTasks, habits) {
   return byDay;
 }
 
-export function initCalendar(elements, notifyError) {
+export function initCalendar(elements) {
   let viewDate = new Date();
   let viewMode = "month";
-  let eventsById = {};
   let tasksById = {};
   let dailyTasksById = {};
   let habitsById = {};
 
-  function setMonthLabel() {
-    elements.calendarMonthLabel.textContent = getMonthLabel(viewDate, viewMode);
-  }
-
-  async function handleCreateEvent() {
-    try {
-      await createCalendarEvent({
-        title: elements.calendarTitleInput.value,
-        startAt: elements.calendarStartInput.value,
-        endAt: elements.calendarEndInput.value,
-        notes: elements.calendarNotesInput.value,
-        linkType: elements.calendarLinkTypeInput.value,
-        linkId: elements.calendarLinkIdInput.value,
-      });
-      elements.calendarTitleInput.value = "";
-      elements.calendarNotesInput.value = "";
-      elements.calendarLinkTypeInput.value = "";
-      elements.calendarLinkIdInput.value = "";
-    } catch (error) {
-      notifyError(error, "Failed to create event");
-    }
-  }
-
-  async function handleEditEvent(eventId, event) {
-    const title = prompt("Edit event title:", event.title || "");
-    if (title === null) return;
-    const startAt = prompt(
-      "Edit start date/time (YYYY-MM-DDTHH:mm):",
-      formatDateTimeValue(event.startAt),
-    );
-    if (startAt === null) return;
-    const endAt = prompt(
-      "Edit end date/time (YYYY-MM-DDTHH:mm):",
-      formatDateTimeValue(event.endAt),
-    );
-    if (endAt === null) return;
-
-    try {
-      await updateCalendarEvent(eventId, { title, startAt, endAt });
-    } catch (error) {
-      notifyError(error, "Failed to update event");
-    }
-  }
-
   function render() {
-    setMonthLabel();
+    elements.calendarMonthLabel.textContent = getMonthLabel(viewDate, viewMode);
     elements.calendarWeekdays.innerHTML = "";
 
     if (viewMode !== "day") {
@@ -190,19 +129,7 @@ export function initCalendar(elements, notifyError) {
     }
 
     const gridDays = getDaysGrid(viewDate, viewMode);
-    const byDay = new Map();
-
-    Object.entries(eventsById || {}).forEach(([id, event]) => {
-      const key = toDayKey(new Date(event.startAt || 0));
-      if (!byDay.has(key)) byDay.set(key, []);
-      byDay.get(key).push({ id, ...event, isGenerated: false });
-    });
-
-    const generated = scheduledItems(gridDays, tasksById, dailyTasksById, habitsById);
-    generated.forEach((rows, key) => {
-      if (!byDay.has(key)) byDay.set(key, []);
-      byDay.get(key).push(...rows.map((item) => ({ ...item, isGenerated: true })));
-    });
+    const byDay = scheduledItems(gridDays, tasksById, dailyTasksById, habitsById);
 
     elements.calendarGrid.innerHTML = "";
     elements.calendarGrid.style.gridTemplateColumns =
@@ -231,29 +158,10 @@ export function initCalendar(elements, notifyError) {
           row.className = "calendar-event";
 
           const text = document.createElement("button");
-          text.className = `calendar-event-btn${event.isGenerated ? " is-generated" : ""}`;
-          const tag = event.kind
-            ? ` [${event.kind}]`
-            : event.linkType
-              ? ` [${event.linkType}]`
-              : "";
-          text.textContent = `${formatTimeRange(event)} ${event.title}${tag}`;
-          if (!event.isGenerated) {
-            text.addEventListener("click", () => handleEditEvent(event.id, event));
-          }
-
+          text.className = "calendar-event-btn is-generated";
+          text.disabled = true;
+          text.textContent = `${formatTimeRange(event)} ${event.title} [${event.kind}]`;
           row.appendChild(text);
-
-          if (!event.isGenerated) {
-            const removeBtn = document.createElement("button");
-            removeBtn.className = "btn-danger";
-            removeBtn.textContent = "X";
-            removeBtn.addEventListener("click", () =>
-              deleteCalendarEvent(event.id).catch((e) => notifyError(e, "Failed to delete event")),
-            );
-            row.appendChild(removeBtn);
-          }
-
           cell.appendChild(row);
         });
 
@@ -261,7 +169,6 @@ export function initCalendar(elements, notifyError) {
     });
   }
 
-  elements.addCalendarEventBtn.addEventListener("click", handleCreateEvent);
   elements.calendarPrevMonthBtn.addEventListener("click", () => {
     const delta = viewMode === "day" ? -1 : viewMode === "week" ? -7 : -30;
     viewDate = new Date(viewDate.getFullYear(), viewDate.getMonth(), viewDate.getDate() + delta);
@@ -290,10 +197,6 @@ export function initCalendar(elements, notifyError) {
   });
 
   const unsubscribers = [
-    subscribeCalendarEvents((events) => {
-      eventsById = events || {};
-      render();
-    }),
     tasksApi.subscribe((tasks) => {
       tasksById = tasks || {};
       render();

--- a/src/modules/habits.js
+++ b/src/modules/habits.js
@@ -5,7 +5,137 @@ import {
   subscribeHabits,
 } from "../services/habitService.js";
 
+function formatDate(ts) {
+  return ts ? new Date(ts).toLocaleString() : "-";
+}
+
+function takeCreationSlot(owner) {
+  if (window.__activeCreationCardOwner && window.__activeCreationCardOwner !== owner) {
+    return false;
+  }
+  window.__activeCreationCardOwner = owner;
+  return true;
+}
+
+function releaseCreationSlot(owner) {
+  if (window.__activeCreationCardOwner === owner) {
+    window.__activeCreationCardOwner = null;
+  }
+}
+
+function makeCard({ title, description = "", metadata = [], actions = [] }) {
+  const card = document.createElement("article");
+  card.className = "work-card";
+
+  const heading = document.createElement("h4");
+  heading.className = "work-card-title";
+  heading.textContent = title;
+  card.appendChild(heading);
+
+  if (description) {
+    const desc = document.createElement("p");
+    desc.className = "work-card-description";
+    desc.textContent = description;
+    card.appendChild(desc);
+  }
+
+  const meta = document.createElement("div");
+  meta.className = "work-card-meta";
+  metadata.forEach((item) => {
+    const row = document.createElement("span");
+    row.textContent = item;
+    meta.appendChild(row);
+  });
+  card.appendChild(meta);
+
+  const actionWrap = document.createElement("div");
+  actionWrap.className = "item-actions";
+  actions.forEach(({ label, onClick, className }) => {
+    const btn = document.createElement("button");
+    btn.textContent = label;
+    btn.className = className || "";
+    btn.addEventListener("click", onClick);
+    actionWrap.appendChild(btn);
+  });
+  card.appendChild(actionWrap);
+
+  return card;
+}
+
 export function initHabits(elements, notifyError) {
+  let isCreationOpen = false;
+
+  function renderCreationCard() {
+    elements.habitCreationArea.innerHTML = "";
+    if (!isCreationOpen) return;
+
+    const card = document.createElement("article");
+    card.className = "work-card creation-card";
+
+    const title = document.createElement("input");
+    title.type = "text";
+    title.placeholder = "Habit title";
+
+    const day = document.createElement("select");
+    [
+      [1, "Monday"],
+      [2, "Tuesday"],
+      [3, "Wednesday"],
+      [4, "Thursday"],
+      [5, "Friday"],
+      [6, "Saturday"],
+      [0, "Sunday"],
+    ].forEach(([value, label]) => {
+      const opt = document.createElement("option");
+      opt.value = String(value);
+      opt.textContent = label;
+      day.appendChild(opt);
+    });
+
+    const time = document.createElement("input");
+    time.type = "time";
+    time.value = "09:00";
+
+    const description = document.createElement("input");
+    description.type = "text";
+    description.placeholder = "Description optional";
+
+    const actions = document.createElement("div");
+    actions.className = "item-actions";
+
+    const createBtn = document.createElement("button");
+    createBtn.textContent = "Create";
+    createBtn.addEventListener("click", async () => {
+      try {
+        await createHabit({
+          title: title.value,
+          dayOfWeek: Number(day.value),
+          time: time.value || "09:00",
+          condition: description.value,
+        });
+        isCreationOpen = false;
+        releaseCreationSlot("habit");
+        renderCreationCard();
+      } catch (error) {
+        notifyError(error, "Failed to create habit");
+      }
+    });
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.className = "btn-muted";
+    cancelBtn.addEventListener("click", () => {
+      isCreationOpen = false;
+      releaseCreationSlot("habit");
+      renderCreationCard();
+    });
+
+    actions.append(createBtn, cancelBtn);
+    card.append(title, day, time, description, actions);
+    elements.habitCreationArea.appendChild(card);
+    title.focus();
+  }
+
   async function onCompleteHabit(habitId, habit) {
     try {
       await completeHabit(habitId, habit);
@@ -14,52 +144,49 @@ export function initHabits(elements, notifyError) {
     }
   }
 
-  async function onCreateHabit() {
-    try {
-      await createHabit({
-        title: elements.habitInput.value,
-        dayOfWeek: Number(elements.habitDayInput.value),
-        time: elements.habitTimeInput.value || "09:00",
-        condition: elements.habitConditionInput.value,
-      });
-      elements.habitInput.value = "";
-      elements.habitConditionInput.value = "";
-    } catch (error) {
-      notifyError(error, "Failed to create habit");
+  elements.addHabitBtn.addEventListener("click", () => {
+    if (!isCreationOpen && !takeCreationSlot("habit")) return;
+    if (isCreationOpen) {
+      isCreationOpen = false;
+      releaseCreationSlot("habit");
+    } else {
+      isCreationOpen = true;
     }
-  }
-
-  elements.addHabitBtn.addEventListener("click", onCreateHabit);
+    renderCreationCard();
+  });
 
   return subscribeHabits((habits) => {
     elements.habitList.innerHTML = "";
     if (!habits) return;
 
     Object.entries(habits).forEach(([id, habit]) => {
+      const isDoneToday = habit.lastCompleted === new Date().toDateString();
       const li = document.createElement("li");
-      const row = document.createElement("div");
-      row.className = "item-actions";
-      const title = document.createElement("span");
-      title.textContent = `${habit.title} (streak: ${habit.streak || 0}) • D${habit.schedule?.dayOfWeek ?? "?"} ${habit.schedule?.time || ""}${habit.condition ? ` • ${habit.condition}` : ""}`;
-      const tick = document.createElement("input");
-      tick.type = "checkbox";
-      tick.className = "habit-tick";
-      tick.checked = habit.lastCompleted === new Date().toDateString();
-      tick.addEventListener("change", () => {
-        if (tick.checked) onCompleteHabit(id, habit);
-      });
-
-      const remove = document.createElement("button");
-      remove.className = "btn-danger";
-      remove.textContent = "Delete";
-      remove.addEventListener("click", () =>
-        deleteHabit(id).catch((e) => notifyError(e, "Failed to delete habit")),
+      li.appendChild(
+        makeCard({
+          title: habit.title,
+          description: habit.condition || "",
+          metadata: [
+            `Schedule: weekly D${habit.schedule?.dayOfWeek ?? "?"} ${habit.schedule?.time || ""}`,
+            `Streak: ${habit.streak || 0}`,
+            `Created: ${formatDate(habit.createdAt)}`,
+            `Completed: ${habit.completedAt ? formatDate(habit.completedAt) : "-"}`,
+          ],
+          actions: [
+            {
+              label: isDoneToday ? "Completed" : "Complete",
+              className: isDoneToday ? "btn-muted" : "",
+              onClick: () => onCompleteHabit(id, habit),
+            },
+            {
+              label: "Delete",
+              className: "btn-danger",
+              onClick: () =>
+                deleteHabit(id).catch((e) => notifyError(e, "Failed to delete habit")),
+            },
+          ],
+        }),
       );
-
-      row.appendChild(title);
-      row.appendChild(tick);
-      row.appendChild(remove);
-      li.appendChild(row);
       elements.habitList.appendChild(li);
     });
   });

--- a/src/modules/tasks.js
+++ b/src/modules/tasks.js
@@ -12,77 +12,188 @@ import {
   subscribeTasks,
 } from "../services/taskService.js";
 
-function buildActions(actions) {
-  const wrap = document.createElement("div");
-  wrap.className = "item-actions";
-  actions.forEach(({ label, onClick, className }) => {
-    const btn = document.createElement("button");
-    btn.textContent = label;
-    btn.className = className || "";
-    btn.addEventListener("click", onClick);
-    wrap.appendChild(btn);
+const STATUS_LABELS = {
+  backlog: "Backlog",
+  todo: "Todo",
+  in_progress: "In Progress",
+  done: "Done",
+};
+
+const KANBAN_COLUMNS = [
+  { key: "backlog", elementKey: "kanbanBacklog" },
+  { key: "todo", elementKey: "kanbanTodo" },
+  { key: "in_progress", elementKey: "kanbanInProgress" },
+  { key: "done", elementKey: "kanbanDone" },
+];
+
+function formatDate(ts) {
+  return ts ? new Date(ts).toLocaleString() : "-";
+}
+
+function takeCreationSlot(owner) {
+  if (window.__activeCreationCardOwner && window.__activeCreationCardOwner !== owner) {
+    return false;
+  }
+  window.__activeCreationCardOwner = owner;
+  return true;
+}
+
+function releaseCreationSlot(owner) {
+  if (window.__activeCreationCardOwner === owner) {
+    window.__activeCreationCardOwner = null;
+  }
+}
+
+function makeCard({ title, description = "", metadata = [], actions = [] }) {
+  const card = document.createElement("article");
+  card.className = "work-card";
+
+  const heading = document.createElement("h4");
+  heading.className = "work-card-title";
+  heading.textContent = title;
+  card.appendChild(heading);
+
+  if (description) {
+    const desc = document.createElement("p");
+    desc.className = "work-card-description";
+    desc.textContent = description;
+    card.appendChild(desc);
+  }
+
+  const meta = document.createElement("div");
+  meta.className = "work-card-meta";
+  metadata.forEach((item) => {
+    const tag = document.createElement("span");
+    tag.textContent = item;
+    meta.appendChild(tag);
   });
-  return wrap;
+  card.appendChild(meta);
+
+  if (actions.length) {
+    const actionWrap = document.createElement("div");
+    actionWrap.className = "item-actions";
+    actions.forEach(({ label, onClick, className, type = "button" }) => {
+      const btn = document.createElement("button");
+      btn.type = type;
+      btn.textContent = label;
+      btn.className = className || "";
+      btn.addEventListener("click", onClick);
+      actionWrap.appendChild(btn);
+    });
+    card.appendChild(actionWrap);
+  }
+
+  return card;
 }
 
 function statusLabel(status, completed) {
   if (status) return status;
-  return completed ? "done" : "new";
-}
-
-function renderTaskCard(task) {
-  const status = statusLabel(task.status, task.completed);
-  const schedule = task.schedule?.specificAt
-    ? new Date(task.schedule.specificAt).toLocaleString()
-    : task.schedule?.mode === "daily"
-      ? `daily ${task.schedule.time || ""}`
-      : task.schedule?.mode === "weekly"
-        ? `weekly D${task.schedule.dayOfWeek} ${task.schedule.time || ""}`
-        : "unscheduled";
-
-  const condition = task.condition ? ` • if: ${task.condition}` : "";
-  return `${task.title} • ${task.type || "task"} • ${task.priority || "medium"} • ${status} • ${schedule}${condition}${
-    task.description ? ` — ${task.description}` : ""
-  }`;
+  return completed ? "done" : "backlog";
 }
 
 export function initTasks(elements, notifyError) {
   let taskMap = {};
+  let dailyTasksById = {};
   let boardDropBound = false;
+  let isDailyCreationOpen = false;
+
+  function renderDailyCreationCard() {
+    elements.dailyTaskCreationArea.innerHTML = "";
+
+    if (!isDailyCreationOpen) return;
+
+    const card = document.createElement("article");
+    card.className = "work-card creation-card";
+
+    const title = document.createElement("input");
+    title.type = "text";
+    title.placeholder = "Daily task title";
+
+    const time = document.createElement("input");
+    time.type = "time";
+    time.value = "09:00";
+
+    const desc = document.createElement("input");
+    desc.type = "text";
+    desc.placeholder = "Description optional";
+
+    const actions = document.createElement("div");
+    actions.className = "item-actions";
+
+    const createBtn = document.createElement("button");
+    createBtn.textContent = "Create";
+    createBtn.addEventListener("click", async () => {
+      try {
+        await createDailyTask({
+          title: title.value,
+          time: time.value || "09:00",
+          condition: desc.value,
+        });
+        isDailyCreationOpen = false;
+        releaseCreationSlot("daily");
+        renderDailyCreationCard();
+      } catch (error) {
+        notifyError(error, "Failed to create daily task");
+      }
+    });
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.className = "btn-muted";
+    cancelBtn.addEventListener("click", () => {
+      isDailyCreationOpen = false;
+      releaseCreationSlot("daily");
+      renderDailyCreationCard();
+    });
+
+    actions.appendChild(createBtn);
+    actions.appendChild(cancelBtn);
+    card.append(title, time, desc, actions);
+    elements.dailyTaskCreationArea.appendChild(card);
+    title.focus();
+  }
 
   function renderKanban(tasks) {
-    const columns = {
-      new: elements.kanbanNew,
-      progress: elements.kanbanProgress,
-      done: elements.kanbanDone,
-      canceled: elements.kanbanCanceled,
-    };
+    const columns = KANBAN_COLUMNS.reduce((acc, col) => {
+      acc[col.key] = elements[col.elementKey];
+      return acc;
+    }, {});
 
     Object.values(columns).forEach((el) => {
       if (el) el.innerHTML = "";
     });
 
-    Object.entries(tasks)
-      .filter(([, task]) => task.type !== "daily" && task.type !== "habit")
-      .forEach(([id, task]) => {
-        const status = statusLabel(task.status, task.completed);
-        const bucket = columns[status] || columns.new;
-        if (!bucket) return;
+    const taskRows = Object.entries(tasks).filter(([, task]) => task.type === "task");
 
-        const li = document.createElement("li");
-        li.textContent = `${task.title} (${task.priority || "medium"})`;
-        li.draggable = true;
-        li.dataset.taskId = id;
-        li.addEventListener("dragstart", (event) => {
-          event.dataTransfer.setData("text/plain", id);
-        });
-        bucket.appendChild(li);
+    taskRows.forEach(([id, task]) => {
+      const status = statusLabel(task.status, task.completed);
+      const bucket = columns[status] || columns.backlog;
+      if (!bucket) return;
+
+      const li = document.createElement("li");
+      const card = makeCard({
+        title: task.title,
+        description: task.description,
+        metadata: [
+          `Status: ${STATUS_LABELS[status] || status}`,
+          `Created: ${formatDate(task.createdAt)}`,
+        ],
       });
+      card.draggable = true;
+      card.dataset.taskId = id;
+      card.classList.add("kanban-card");
+      card.addEventListener("dragstart", (event) => {
+        event.dataTransfer.setData("text/plain", id);
+      });
+      li.appendChild(card);
+      bucket.appendChild(li);
+    });
 
     if (boardDropBound) return;
     boardDropBound = true;
 
-    Object.entries(columns).forEach(([nextStatus, column]) => {
+    KANBAN_COLUMNS.forEach(({ key, elementKey }) => {
+      const column = elements[elementKey];
       if (!column) return;
       column.addEventListener("dragover", (event) => event.preventDefault());
       column.addEventListener("drop", async (event) => {
@@ -90,7 +201,7 @@ export function initTasks(elements, notifyError) {
         const taskId = event.dataTransfer.getData("text/plain");
         if (!taskId || !taskMap[taskId]) return;
         try {
-          await updateTask(taskId, { status: nextStatus });
+          await updateTask(taskId, { status: key });
         } catch (error) {
           notifyError(error, "Failed to update task status");
         }
@@ -114,20 +225,6 @@ export function initTasks(elements, notifyError) {
       elements.taskScheduleInput.value = "";
     } catch (error) {
       notifyError(error, "Failed to add task");
-    }
-  }
-
-  async function addDailyItem() {
-    try {
-      await createDailyTask({
-        title: elements.dailyTaskInput.value,
-        time: elements.dailyTaskTimeInput.value || "09:00",
-        condition: elements.dailyTaskConditionInput.value,
-      });
-      elements.dailyTaskInput.value = "";
-      elements.dailyTaskConditionInput.value = "";
-    } catch (error) {
-      notifyError(error, "Failed to create daily task");
     }
   }
 
@@ -161,35 +258,45 @@ export function initTasks(elements, notifyError) {
 
   function loadDailyTasks() {
     return subscribeDailyTasks((tasks) => {
+      dailyTasksById = tasks || {};
       elements.dailyTaskList.innerHTML = "";
-      const rows = tasks ? Object.entries(tasks) : [];
+      const rows = Object.entries(dailyTasksById);
       let completedCount = 0;
       const today = new Date().toDateString();
 
       rows.forEach(([id, task]) => {
-        const li = document.createElement("li");
-        const title = document.createElement("span");
-        title.textContent = `${task.title} (${task.schedule?.time || "--:--"})${task.condition ? ` • ${task.condition}` : ""}`;
-        li.appendChild(title);
-
         const isDoneToday = task.lastCompleted === today;
         if (isDoneToday) completedCount += 1;
 
+        const li = document.createElement("li");
         li.appendChild(
-          buildActions([
-            {
-              label: "Complete",
-              className: isDoneToday ? "btn-muted" : "",
-              onClick: () =>
-                completeDailyTask(id).catch((e) => notifyError(e, "Failed to complete daily task")),
-            },
-            {
-              label: "Delete",
-              className: "btn-danger",
-              onClick: () =>
-                deleteDailyTask(id).catch((e) => notifyError(e, "Failed to delete daily task")),
-            },
-          ]),
+          makeCard({
+            title: task.title,
+            description: task.condition || "",
+            metadata: [
+              `Schedule: daily ${task.schedule?.time || "--:--"}`,
+              `Created: ${formatDate(task.createdAt)}`,
+              `Completed: ${task.completedAt ? formatDate(task.completedAt) : "-"}`,
+            ],
+            actions: [
+              {
+                label: "Complete",
+                className: isDoneToday ? "btn-muted" : "",
+                onClick: () =>
+                  completeDailyTask(id).catch((e) =>
+                    notifyError(e, "Failed to complete daily task"),
+                  ),
+              },
+              {
+                label: "Delete",
+                className: "btn-danger",
+                onClick: () =>
+                  deleteDailyTask(id).catch((e) =>
+                    notifyError(e, "Failed to delete daily task"),
+                  ),
+              },
+            ],
+          }),
         );
         elements.dailyTaskList.appendChild(li);
       });
@@ -207,39 +314,71 @@ export function initTasks(elements, notifyError) {
         return;
       }
 
-      Object.entries(tasks)
+      const taskRows = Object.entries(tasks).filter(([, task]) => task.type === "task");
+
+      taskRows
         .sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0))
         .forEach(([id, task]) => {
+          const status = statusLabel(task.status, task.completed);
           const li = document.createElement("li");
-          const text = document.createElement("div");
-          text.className = "item-main";
-          text.textContent = renderTaskCard(task);
-          if (task.completed || task.status === "done") text.classList.add("is-completed");
-          li.appendChild(text);
           li.appendChild(
-            buildActions([
-              {
-                label: "Complete",
-                className: task.completed ? "btn-muted" : "",
-                onClick: () => completeTask(id, task),
-              },
-              { label: "Edit", onClick: () => editTask(id, task) },
-              {
-                label: "Delete",
-                className: "btn-danger",
-                onClick: () => deleteTask(id).catch((e) => notifyError(e, "Failed to delete task")),
-              },
-            ]),
+            makeCard({
+              title: task.title,
+              description: task.description,
+              metadata: [
+                `Status: ${STATUS_LABELS[status] || status}`,
+                `Created: ${formatDate(task.createdAt)}`,
+                `Completed: ${task.completedAt ? formatDate(task.completedAt) : "-"}`,
+              ],
+              actions: [
+                {
+                  label: "Complete",
+                  className: task.completed ? "btn-muted" : "",
+                  onClick: () => completeTask(id, task),
+                },
+                { label: "Edit", onClick: () => editTask(id, task) },
+                {
+                  label: "Delete",
+                  className: "btn-danger",
+                  onClick: () =>
+                    deleteTask(id).catch((e) => notifyError(e, "Failed to delete task")),
+                },
+              ],
+            }),
           );
           elements.taskList.appendChild(li);
         });
 
-      renderKanban(tasks);
+      const grouped = {
+        backlog: taskRows
+          .filter(([, task]) => statusLabel(task.status, task.completed) === "backlog")
+          .sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0)),
+        todo: taskRows
+          .filter(([, task]) => statusLabel(task.status, task.completed) === "todo")
+          .sort(([, a], [, b]) => (a.createdAt || 0) - (b.createdAt || 0)),
+        in_progress: taskRows
+          .filter(([, task]) => statusLabel(task.status, task.completed) === "in_progress")
+          .sort(([, a], [, b]) => (a.createdAt || 0) - (b.createdAt || 0)),
+        done: taskRows
+          .filter(([, task]) => statusLabel(task.status, task.completed) === "done")
+          .sort(([, a], [, b]) => (a.createdAt || 0) - (b.createdAt || 0)),
+      };
+
+      renderKanban(Object.fromEntries(Object.values(grouped).flat()));
     });
   }
 
   elements.addTaskBtn.addEventListener("click", addTask);
-  elements.addDailyTaskBtn.addEventListener("click", addDailyItem);
+  elements.addDailyTaskBtn.addEventListener("click", () => {
+    if (!isDailyCreationOpen && !takeCreationSlot("daily")) return;
+    if (isDailyCreationOpen) {
+      isDailyCreationOpen = false;
+      releaseCreationSlot("daily");
+    } else {
+      isDailyCreationOpen = true;
+    }
+    renderDailyCreationCard();
+  });
 
   return [loadDailyTasks(), loadTasks()];
 }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -44,16 +44,11 @@ const elements = {
   mainViews: document.querySelectorAll(".main-view"),
   calendarTabs: document.getElementById("calendarTabs"),
   calendarModes: document.querySelectorAll(".calendar-mode"),
-  dailyTaskInput: document.getElementById("dailyTaskInput"),
-  dailyTaskTimeInput: document.getElementById("dailyTaskTimeInput"),
-  dailyTaskConditionInput: document.getElementById("dailyTaskConditionInput"),
+  dailyTaskCreationArea: document.getElementById("dailyTaskCreationArea"),
   addDailyTaskBtn: document.getElementById("addDailyTaskBtn"),
   dailyTaskList: document.getElementById("dailyTaskList"),
   dailyProgressText: document.getElementById("dailyProgressText"),
-  habitInput: document.getElementById("habitInput"),
-  habitDayInput: document.getElementById("habitDayInput"),
-  habitTimeInput: document.getElementById("habitTimeInput"),
-  habitConditionInput: document.getElementById("habitConditionInput"),
+  habitCreationArea: document.getElementById("habitCreationArea"),
   addHabitBtn: document.getElementById("addHabitBtn"),
   habitList: document.getElementById("habitList"),
   taskInput: document.getElementById("taskInput"),
@@ -66,10 +61,10 @@ const elements = {
   toggleTaskCreationBtn: document.getElementById("toggleTaskCreationBtn"),
   addTaskBtn: document.getElementById("addTaskBtn"),
   taskList: document.getElementById("taskList"),
-  kanbanNew: document.getElementById("kanban-new"),
-  kanbanProgress: document.getElementById("kanban-progress"),
+  kanbanBacklog: document.getElementById("kanban-backlog"),
+  kanbanTodo: document.getElementById("kanban-todo"),
+  kanbanInProgress: document.getElementById("kanban-in-progress"),
   kanbanDone: document.getElementById("kanban-done"),
-  kanbanCanceled: document.getElementById("kanban-canceled"),
   focusTimer: document.getElementById("focusTimer"),
   focusButtons: document.querySelectorAll(".focus-controls button[data-duration]"),
   cancelFocusBtn: document.getElementById("cancelFocusBtn"),
@@ -86,13 +81,6 @@ const elements = {
   incomeTotal: document.getElementById("incomeTotal"),
   expenseTotal: document.getElementById("expenseTotal"),
   activityLogList: document.getElementById("activityLogList"),
-  calendarTitleInput: document.getElementById("calendarTitleInput"),
-  calendarStartInput: document.getElementById("calendarStartInput"),
-  calendarEndInput: document.getElementById("calendarEndInput"),
-  calendarNotesInput: document.getElementById("calendarNotesInput"),
-  calendarLinkTypeInput: document.getElementById("calendarLinkTypeInput"),
-  calendarLinkIdInput: document.getElementById("calendarLinkIdInput"),
-  addCalendarEventBtn: document.getElementById("addCalendarEventBtn"),
   calendarPrevMonthBtn: document.getElementById("calendarPrevMonthBtn"),
   calendarNextMonthBtn: document.getElementById("calendarNextMonthBtn"),
   calendarTodayBtn: document.getElementById("calendarTodayBtn"),
@@ -156,10 +144,14 @@ function mirrorQuickStats(extra = {}) {
 }
 
 function renderTodaySummary() {
+  const taskCards = elements.taskList.querySelectorAll(".work-card");
+  const completedTasks = Array.from(taskCards).filter((card) =>
+    card.textContent.includes("Status: Done"),
+  ).length;
   const rows = [
     `Daily tasks: ${elements.dailyTaskList.children.length}`,
-    `Open tasks: ${elements.taskList.querySelectorAll(".item-main:not(.is-completed)").length}`,
-    `Completed tasks: ${elements.taskList.querySelectorAll(".item-main.is-completed").length}`,
+    `Open tasks: ${taskCards.length - completedTasks}`,
+    `Completed tasks: ${completedTasks}`,
     `Habits tracked: ${elements.habitList.children.length}`,
   ];
 

--- a/style.css
+++ b/style.css
@@ -61,7 +61,8 @@ body {
 }
 ul {
   margin: 8px 0 0;
-  padding-left: 18px;
+  padding-left: 0;
+  list-style: none;
 }
 li {
   margin-bottom: 6px;
@@ -124,7 +125,7 @@ button {
 }
 .task-columns {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 8px;
 }
 .task-column {
@@ -160,11 +161,6 @@ button {
   border-color: #4d667f;
   color: #b9d3ef;
 }
-.calendar-input {
-  display: grid;
-  gap: 6px;
-  margin-bottom: 10px;
-}
 .calendar-toolbar {
   display: flex;
   gap: 6px;
@@ -192,6 +188,41 @@ button {
   display: grid;
   gap: 6px;
   margin-top: 6px;
+}
+.work-card {
+  background: #111722;
+  border: 1px solid #29354d;
+  border-radius: 10px;
+  padding: 10px;
+}
+.work-card-title {
+  margin: 0;
+  font-size: 14px;
+}
+.work-card-description {
+  margin: 8px 0;
+  font-size: 13px;
+  color: #bac7db;
+}
+.work-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: #9eb1cb;
+}
+.work-card-meta span {
+  border: 1px solid #364966;
+  border-radius: 999px;
+  padding: 2px 7px;
+}
+.creation-card {
+  margin-top: 8px;
+  display: grid;
+  gap: 6px;
+}
+.kanban-card {
+  cursor: grab;
 }
 .habit-tick {
   width: 22px;
@@ -235,5 +266,8 @@ button {
   }
   .task-panel {
     grid-column: 1 / -1;
+  }
+  .task-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a single, consistent Card component for Tasks, Dailies and Habits to simplify UI and enforce consistent metadata/interaction patterns.
- Replace inline always-visible forms with on-demand creation cards to reduce UI clutter and ensure only one creation card is active at a time.
- Convert the Task board to a 4-column Kanban with drag/drop persistence and make the Calendar a read-only aggregator of existing items.

### Description
- Updated work item status model in `src/core/workItemModel.js` to use `"backlog" | "todo" | "in_progress" | "done"` and set new item defaults (`task` → `backlog`, others → `todo`).
- Rewrote `src/modules/tasks.js` to render unified card components, provide a 4-column Kanban (`backlog`, `todo`, `in_progress`, `done`) with drag/drop handlers that call `updateTask(taskId, { status })`, implement per-column sorting (Backlog DESC, others ASC), and add the inline single-active daily-creation card flow.
- Reworked `src/modules/habits.js` to use the same card UI and add the `+ Add Habit` creation-card flow with single-active-creation locking and autofocus behavior.
- Simplified calendar in `src/modules/calendar.js` to remove event create/edit/delete flows and UI inputs, instead materializing read-only scheduled items from tasks, daily tasks and habits and marking them readonly.
- Updated DOM bindings in `src/ui/ui.js` to reflect new element IDs and card classes, and adjusted dashboard summary rendering to count unified cards.
- Updated `index.html` to add Kanban column elements, replace habit/daily inline forms with `+ Add ...` buttons and creation areas, and removed calendar event input controls.
- Added styles in `style.css` for `work-card`, creation cards, kanban layout and visual consistency across items.

### Testing
- Ran `npm test` (unit test suite): all tests passed (5 tests passing).
- Ran `npm run lint` (ESLint): completed without errors.
- Attempted an automated browser screenshot to validate the updated UI, but the headless browser navigation to the local server returned `ERR_EMPTY_RESPONSE` in this environment (visual verification not captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2681027b48323bde2c4b6b35049ae)