### PR TITLE
Fix task board filtering so created tasks appear in backlog

### DIFF
--- a/src/modules/tasks.js
+++ b/src/modules/tasks.js
@@ -26,6 +26,10 @@ const KANBAN_COLUMNS = [
   { key: "done", elementKey: "kanbanDone" },
 ];
 
+function isBoardTask(task) {
+  return task && task.type !== "daily" && task.type !== "habit";
+}
+
 function formatDate(ts) {
   return ts ? new Date(ts).toLocaleString() : "-";
 }
@@ -163,7 +167,7 @@ export function initTasks(elements, notifyError) {
       if (el) el.innerHTML = "";
     });
 
-    const taskRows = Object.entries(tasks).filter(([, task]) => task.type === "task");
+    const taskRows = Object.entries(tasks).filter(([, task]) => isBoardTask(task));
 
     taskRows.forEach(([id, task]) => {
       const status = statusLabel(task.status, task.completed);
@@ -314,7 +318,7 @@ export function initTasks(elements, notifyError) {
         return;
       }
 
-      const taskRows = Object.entries(tasks).filter(([, task]) => task.type === "task");
+      const taskRows = Object.entries(tasks).filter(([, task]) => isBoardTask(task));
 
       taskRows
         .sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0))


### PR DESCRIPTION
### Motivation
- The task creation form uses `type` values like `work`, `personal`, and `study` while the board rendering previously filtered only `task` entries, causing newly created tasks to be excluded from the Kanban/backlog display. 

### Description
- Added a shared helper `isBoardTask(task)` in `src/modules/tasks.js` that treats any non-`daily`/non-`habit` item as a board-eligible work item. 
- Replaced the previous `task.type === "task"` filters with `isBoardTask(task)` in both the Kanban renderer (`renderKanban`) and the list loader (`loadTasks`).
- No changes to persistence or service APIs; the fix is entirely in UI rendering logic (`src/modules/tasks.js`).

### Testing
- Ran unit tests with `npm test -- --runInBand` and all tests passed (5/5). 
- Ran linter with `npm run lint` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b26c1b0e9c83239ae17827ca04473b)