### PR TITLE
Split Tracking vs Settings: add Settings UI, daily reset, quick note, task status & DB reset controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,11 @@
         <h2>Mode</h2>
         <nav class="sidebar-nav" id="sidebarNav">
           <button class="nav-btn is-active" data-view="dashboard" title="Dashboard">🏠</button>
+          <button class="nav-btn" data-view="tasks" title="Tasks">✅</button>
           <button class="nav-btn" data-view="calendar" title="Calendar">📅</button>
-          <button class="nav-btn" data-view="focus" title="Focus">🎯</button>
           <button class="nav-btn" data-view="notes" title="Notes">📝</button>
+          <button class="nav-btn" data-view="settings" title="Settings">⚙️</button>
+          <button class="nav-btn" data-view="focus" title="Focus">🎯</button>
           <button class="nav-btn" data-view="finance" title="Finance">💰</button>
           <button class="nav-btn" data-view="stats" title="Stats">📊</button>
         </nav>
@@ -23,16 +25,6 @@
 
       <main class="main-area">
         <section class="main-view is-active" data-view="dashboard">
-          <section class="card">
-            <h2>Today Summary</h2>
-            <ul id="todaySummaryList"></ul>
-          </section>
-
-          <section class="card">
-            <h2>Today's Calendar Events</h2>
-            <ul id="todayEventsList"></ul>
-          </section>
-
           <section class="card">
             <h2>Quick Stats (EXP / Focus today)</h2>
             <div class="quick-stats-grid">
@@ -47,9 +39,64 @@
             </div>
           </section>
 
+          <section class="card" id="dateTimeCard">
+            <h2>Date & Time</h2>
+            <div class="date-time-day" id="currentDayOfWeek">-</div>
+            <div id="currentDate">-</div>
+            <div class="date-time-clock" id="currentTime">-</div>
+          </section>
+
+          <section class="card" id="quickNoteCard">
+            <h2>Quick Note</h2>
+            <textarea
+              id="quickNoteInput"
+              placeholder="Temporary scratch note (not saved until you push)..."
+            ></textarea>
+            <div class="item-actions">
+              <button id="quickNoteClearBtn" class="btn-muted">Clear</button>
+              <button id="quickNotePushBtn">Push to Notes</button>
+            </div>
+          </section>
+
+          <section class="card">
+            <h2>Today Summary</h2>
+            <ul id="todaySummaryList"></ul>
+          </section>
+
+          <section class="card">
+            <h2>Today's Calendar Events</h2>
+            <ul id="todayEventsList"></ul>
+          </section>
+
           <section class="card activity">
             <h2>Recent Activity</h2>
             <ul id="activityLogList"></ul>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="tasks">
+          <section class="card">
+            <h2>Tasks</h2>
+            <button id="toggleTaskCreationBtn">Create Task</button>
+            <div id="taskCreationPanel" class="task-creation-panel">
+              <input type="text" id="taskInput" placeholder="Task title" />
+              <textarea id="taskDescriptionInput" placeholder="Task description"></textarea>
+              <input type="text" id="taskConditionInput" placeholder="Condition" />
+              <select id="taskTypeInput">
+                <option value="work">work</option>
+                <option value="personal">personal</option>
+                <option value="study">study</option>
+                <option value="task">task</option>
+              </select>
+              <select id="taskPriorityInput">
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+              </select>
+              <input type="datetime-local" id="taskScheduleInput" />
+              <button id="addTaskBtn">Save Task</button>
+            </div>
+            <ul id="taskList"></ul>
           </section>
         </section>
 
@@ -101,6 +148,37 @@
                 <div class="calendar-grid" id="calendarGrid"></div>
               </section>
             </section>
+          </section>
+        </section>
+
+        <section class="main-view" data-view="settings">
+          <section class="card">
+            <h2>Settings</h2>
+            <div class="settings-grid">
+              <section>
+                <h3>Daily Task Setup</h3>
+                <button id="settingsAddDailyTaskBtn">+ Add Daily Task</button>
+                <div id="settingsDailyTaskCreationArea"></div>
+                <ul id="settingsDailyTaskList"></ul>
+              </section>
+
+              <section>
+                <h3>Habit Setup</h3>
+                <button id="settingsAddHabitBtn">+ Add Habit</button>
+                <div id="settingsHabitCreationArea"></div>
+                <ul id="settingsHabitList"></ul>
+              </section>
+
+              <section>
+                <h3>Database Controls</h3>
+                <p>All reset actions require two-step confirmation.</p>
+                <div class="item-actions settings-reset-actions">
+                  <button id="resetTasksBtn" class="btn-danger">Reset Tasks</button>
+                  <button id="resetStatsBtn" class="btn-danger">Reset Stats</button>
+                  <button id="resetDatabaseBtn" class="btn-danger">Reset Entire Database</button>
+                </div>
+              </section>
+            </div>
           </section>
         </section>
 
@@ -189,44 +267,26 @@
       </main>
 
       <aside class="task-panel card">
-        <h2>Actions</h2>
+        <h2>Tracking</h2>
 
         <section>
           <h3>Daily Tasks <small id="dailyProgressText">0/0 completed</small></h3>
-          <button id="addDailyTaskBtn">+ Add Daily Task</button>
-          <div id="dailyTaskCreationArea"></div>
+          <div class="tracking-tabs" id="dailyTrackingTabs">
+            <button class="is-active" data-tab="active">Active</button>
+            <button data-tab="completed">Completed</button>
+            <button data-tab="all">All</button>
+          </div>
           <ul id="dailyTaskList"></ul>
         </section>
 
         <section>
           <h3>Habits</h3>
-          <button id="addHabitBtn">+ Add Habit</button>
-          <div id="habitCreationArea"></div>
-          <ul id="habitList"></ul>
-        </section>
-
-        <section>
-          <h3>Tasks</h3>
-          <button id="toggleTaskCreationBtn">Create Task</button>
-          <div id="taskCreationPanel" class="task-creation-panel">
-            <input type="text" id="taskInput" placeholder="Task title" />
-            <textarea id="taskDescriptionInput" placeholder="Task description"></textarea>
-            <input type="text" id="taskConditionInput" placeholder="Condition" />
-            <select id="taskTypeInput">
-              <option value="work">work</option>
-              <option value="personal">personal</option>
-              <option value="study">study</option>
-              <option value="task">task</option>
-            </select>
-            <select id="taskPriorityInput">
-              <option value="low">low</option>
-              <option value="medium">medium</option>
-              <option value="high">high</option>
-            </select>
-            <input type="datetime-local" id="taskScheduleInput" />
-            <button id="addTaskBtn">Save Task</button>
+          <div class="tracking-tabs" id="habitTrackingTabs">
+            <button class="is-active" data-tab="active">Active</button>
+            <button data-tab="completed">Completed</button>
+            <button data-tab="all">All</button>
           </div>
-          <ul id="taskList"></ul>
+          <ul id="habitList"></ul>
         </section>
       </aside>
     </div>

--- a/src/core/firebase.js
+++ b/src/core/firebase.js
@@ -10,4 +10,6 @@ export {
   focusApi,
   activityApi,
   calendarApi,
+  resetTasksDomain,
+  resetEntireDatabase,
 } from "./firebaseService.js";

--- a/src/core/firebaseService.js
+++ b/src/core/firebaseService.js
@@ -104,6 +104,18 @@ export const statsApi = {
   get: () => read(PATHS.stats),
   set: (stats) => write(PATHS.stats, stats),
   transact: (updater) => transaction(PATHS.stats, updater),
+  reset: () =>
+    write(PATHS.stats, {
+      atk: 0,
+      int: 0,
+      disc: 0,
+      cre: 0,
+      end: 0,
+      foc: 0,
+      wis: 0,
+      level: 1,
+      exp: 0,
+    }),
 };
 
 export const tasksApi = {
@@ -134,6 +146,7 @@ export const financeApi = {
 export const dailyTasksApi = {
   add: (task) => create(PATHS.dailyTasks, task),
   subscribe: (callback) => subscribe(PATHS.dailyTasks, callback),
+  list: () => read(PATHS.dailyTasks),
   getById: (taskId) => read(`${PATHS.dailyTasks}/${taskId}`),
   patchById: (taskId, value) => patch(`${PATHS.dailyTasks}/${taskId}`, value),
   deleteById: (taskId) => destroy(`${PATHS.dailyTasks}/${taskId}`),
@@ -142,6 +155,7 @@ export const dailyTasksApi = {
 export const habitsApi = {
   add: (habit) => create(PATHS.habits, habit),
   subscribe: (callback) => subscribe(PATHS.habits, callback),
+  list: () => read(PATHS.habits),
   getById: (habitId) => read(`${PATHS.habits}/${habitId}`),
   patchById: (habitId, value) => patch(`${PATHS.habits}/${habitId}`, value),
   deleteById: (habitId) => destroy(`${PATHS.habits}/${habitId}`),
@@ -170,3 +184,15 @@ export const calendarApi = {
   updateEventById: (eventId, value) => patch(`${PATHS.calendarEvents}/${eventId}`, value),
   deleteEventById: (eventId) => destroy(`${PATHS.calendarEvents}/${eventId}`),
 };
+
+export async function resetTasksDomain() {
+  await Promise.all([
+    write(PATHS.tasks, null),
+    write(PATHS.dailyTasks, null),
+    write(PATHS.habits, null),
+  ]);
+}
+
+export async function resetEntireDatabase() {
+  await write("/", null);
+}

--- a/src/core/workItemModel.js
+++ b/src/core/workItemModel.js
@@ -1,6 +1,6 @@
 import { requireEnum, requireNonEmptyText } from "./validation.js";
 
-const STATUS_VALUES = ["backlog", "todo", "in_progress", "done"];
+const STATUS_VALUES = ["backlog", "todo", "in_progress", "done", "cancelled"];
 const PRIORITY_VALUES = ["low", "medium", "high"];
 const TYPE_VALUES = ["task", "daily", "habit", "work", "personal", "study"];
 

--- a/src/modules/habits.js
+++ b/src/modules/habits.js
@@ -1,193 +1,101 @@
-import {
-  completeHabit,
-  createHabit,
-  deleteHabit,
-  subscribeHabits,
-} from "../services/habitService.js";
+import { completeHabit, subscribeHabits, resetHabitsForToday } from "../services/habitService.js";
 
-function formatDate(ts) {
-  return ts ? new Date(ts).toLocaleString() : "-";
-}
-
-function takeCreationSlot(owner) {
-  if (window.__activeCreationCardOwner && window.__activeCreationCardOwner !== owner) {
-    return false;
-  }
-  window.__activeCreationCardOwner = owner;
-  return true;
-}
-
-function releaseCreationSlot(owner) {
-  if (window.__activeCreationCardOwner === owner) {
-    window.__activeCreationCardOwner = null;
-  }
-}
-
-function makeCard({ title, description = "", metadata = [], actions = [] }) {
+function makeTrackingCard({ title, time, isDoneToday, onComplete }) {
   const card = document.createElement("article");
   card.className = "work-card";
 
   const heading = document.createElement("h4");
   heading.className = "work-card-title";
   heading.textContent = title;
-  card.appendChild(heading);
 
-  if (description) {
-    const desc = document.createElement("p");
-    desc.className = "work-card-description";
-    desc.textContent = description;
-    card.appendChild(desc);
-  }
+  const timeText = document.createElement("p");
+  timeText.className = "work-card-time";
+  timeText.textContent = time || "--:--";
 
-  const meta = document.createElement("div");
-  meta.className = "work-card-meta";
-  metadata.forEach((item) => {
-    const row = document.createElement("span");
-    row.textContent = item;
-    meta.appendChild(row);
-  });
-  card.appendChild(meta);
+  const actions = document.createElement("div");
+  actions.className = "item-actions";
+  const completeBtn = document.createElement("button");
+  completeBtn.textContent = isDoneToday ? "Completed" : "Complete";
+  completeBtn.className = isDoneToday ? "btn-muted" : "";
+  completeBtn.addEventListener("click", onComplete);
 
-  const actionWrap = document.createElement("div");
-  actionWrap.className = "item-actions";
-  actions.forEach(({ label, onClick, className }) => {
-    const btn = document.createElement("button");
-    btn.textContent = label;
-    btn.className = className || "";
-    btn.addEventListener("click", onClick);
-    actionWrap.appendChild(btn);
-  });
-  card.appendChild(actionWrap);
-
+  actions.appendChild(completeBtn);
+  card.append(heading, timeText, actions);
   return card;
 }
 
 export function initHabits(elements, notifyError) {
-  let isCreationOpen = false;
+  let activeHabitTab = "active";
+  let habitsById = {};
 
-  function renderCreationCard() {
-    elements.habitCreationArea.innerHTML = "";
-    if (!isCreationOpen) return;
-
-    const card = document.createElement("article");
-    card.className = "work-card creation-card";
-
-    const title = document.createElement("input");
-    title.type = "text";
-    title.placeholder = "Habit title";
-
-    const day = document.createElement("select");
-    [
-      [1, "Monday"],
-      [2, "Tuesday"],
-      [3, "Wednesday"],
-      [4, "Thursday"],
-      [5, "Friday"],
-      [6, "Saturday"],
-      [0, "Sunday"],
-    ].forEach(([value, label]) => {
-      const opt = document.createElement("option");
-      opt.value = String(value);
-      opt.textContent = label;
-      day.appendChild(opt);
+  function updateTabState() {
+    elements.habitTrackingTabs.querySelectorAll("button[data-tab]").forEach((btn) => {
+      btn.classList.toggle("is-active", btn.dataset.tab === activeHabitTab);
     });
-
-    const time = document.createElement("input");
-    time.type = "time";
-    time.value = "09:00";
-
-    const description = document.createElement("input");
-    description.type = "text";
-    description.placeholder = "Description optional";
-
-    const actions = document.createElement("div");
-    actions.className = "item-actions";
-
-    const createBtn = document.createElement("button");
-    createBtn.textContent = "Create";
-    createBtn.addEventListener("click", async () => {
-      try {
-        await createHabit({
-          title: title.value,
-          dayOfWeek: Number(day.value),
-          time: time.value || "09:00",
-          condition: description.value,
-        });
-        isCreationOpen = false;
-        releaseCreationSlot("habit");
-        renderCreationCard();
-      } catch (error) {
-        notifyError(error, "Failed to create habit");
-      }
-    });
-
-    const cancelBtn = document.createElement("button");
-    cancelBtn.textContent = "Cancel";
-    cancelBtn.className = "btn-muted";
-    cancelBtn.addEventListener("click", () => {
-      isCreationOpen = false;
-      releaseCreationSlot("habit");
-      renderCreationCard();
-    });
-
-    actions.append(createBtn, cancelBtn);
-    card.append(title, day, time, description, actions);
-    elements.habitCreationArea.appendChild(card);
-    title.focus();
   }
 
-  async function onCompleteHabit(habitId, habit) {
-    try {
-      await completeHabit(habitId, habit);
-    } catch (error) {
-      notifyError(error, "Failed to complete habit");
-    }
-  }
-
-  elements.addHabitBtn.addEventListener("click", () => {
-    if (!isCreationOpen && !takeCreationSlot("habit")) return;
-    if (isCreationOpen) {
-      isCreationOpen = false;
-      releaseCreationSlot("habit");
-    } else {
-      isCreationOpen = true;
-    }
-    renderCreationCard();
-  });
-
-  return subscribeHabits((habits) => {
+  function renderHabits() {
     elements.habitList.innerHTML = "";
-    if (!habits) return;
+    const today = new Date().toDateString();
 
-    Object.entries(habits).forEach(([id, habit]) => {
-      const isDoneToday = habit.lastCompleted === new Date().toDateString();
+    Object.entries(habitsById).forEach(([id, habit]) => {
+      const isDoneToday = habit.lastCompleted === today;
+      const hiddenByTab =
+        (activeHabitTab === "active" && isDoneToday) ||
+        (activeHabitTab === "completed" && !isDoneToday);
+      if (hiddenByTab) return;
+
       const li = document.createElement("li");
       li.appendChild(
-        makeCard({
+        makeTrackingCard({
           title: habit.title,
-          description: habit.condition || "",
-          metadata: [
-            `Schedule: weekly D${habit.schedule?.dayOfWeek ?? "?"} ${habit.schedule?.time || ""}`,
-            `Streak: ${habit.streak || 0}`,
-            `Created: ${formatDate(habit.createdAt)}`,
-            `Completed: ${habit.completedAt ? formatDate(habit.completedAt) : "-"}`,
-          ],
-          actions: [
-            {
-              label: isDoneToday ? "Completed" : "Complete",
-              className: isDoneToday ? "btn-muted" : "",
-              onClick: () => onCompleteHabit(id, habit),
-            },
-            {
-              label: "Delete",
-              className: "btn-danger",
-              onClick: () =>
-                deleteHabit(id).catch((e) => notifyError(e, "Failed to delete habit")),
-            },
-          ],
+          time: habit.schedule?.time,
+          isDoneToday,
+          onComplete: () =>
+            completeHabit(id, habit).catch((error) =>
+              notifyError(error, "Failed to complete habit"),
+            ),
         }),
       );
       elements.habitList.appendChild(li);
     });
+  }
+
+  function scheduleDailyReset() {
+    async function runReset() {
+      try {
+        await resetHabitsForToday();
+      } catch (error) {
+        notifyError(error, "Failed to reset habits");
+      }
+    }
+
+    const now = new Date();
+    const nextMidnight = new Date(now);
+    nextMidnight.setHours(24, 0, 0, 0);
+    const timeout = nextMidnight.getTime() - now.getTime();
+
+    setTimeout(() => {
+      runReset();
+      setInterval(runReset, 24 * 60 * 60 * 1000);
+    }, timeout);
+
+    runReset();
+  }
+
+  elements.habitTrackingTabs.addEventListener("click", (event) => {
+    const button = event.target.closest("button[data-tab]");
+    if (!button) return;
+    activeHabitTab = button.dataset.tab;
+    updateTabState();
+    renderHabits();
+  });
+
+  updateTabState();
+  scheduleDailyReset();
+
+  return subscribeHabits((habits) => {
+    habitsById = habits || {};
+    renderHabits();
   });
 }

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -1,0 +1,293 @@
+import { statsApi, resetTasksDomain, resetEntireDatabase } from "../core/firebase.js";
+import {
+  createDailyTask,
+  updateDailyTask,
+  deleteDailyTask,
+  subscribeDailyTasks,
+} from "../services/dailyTaskService.js";
+import {
+  createHabit,
+  updateHabit,
+  deleteHabit,
+  subscribeHabits,
+} from "../services/habitService.js";
+
+function askDoubleConfirmation(label) {
+  const confirmed = window.confirm(`Are you sure you want to ${label}?`);
+  if (!confirmed) return false;
+  const text = window.prompt("Type RESET to confirm");
+  return text === "RESET";
+}
+
+export function initSettings(elements, notifyError) {
+  let isDailyCreationOpen = false;
+  let isHabitCreationOpen = false;
+
+  function renderDailyCreationCard() {
+    elements.settingsDailyTaskCreationArea.innerHTML = "";
+    if (!isDailyCreationOpen) return;
+
+    const card = document.createElement("article");
+    card.className = "work-card creation-card";
+
+    const title = document.createElement("input");
+    title.placeholder = "Daily task title";
+
+    const time = document.createElement("input");
+    time.type = "time";
+    time.value = "09:00";
+
+    const description = document.createElement("input");
+    description.placeholder = "Description optional";
+
+    const actions = document.createElement("div");
+    actions.className = "item-actions";
+
+    const createBtn = document.createElement("button");
+    createBtn.textContent = "Create";
+    createBtn.addEventListener("click", async () => {
+      try {
+        await createDailyTask({
+          title: title.value,
+          time: time.value,
+          condition: description.value,
+        });
+        isDailyCreationOpen = false;
+        renderDailyCreationCard();
+      } catch (error) {
+        notifyError(error, "Failed to create daily task");
+      }
+    });
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.className = "btn-muted";
+    cancelBtn.addEventListener("click", () => {
+      isDailyCreationOpen = false;
+      renderDailyCreationCard();
+    });
+
+    actions.append(createBtn, cancelBtn);
+    card.append(title, time, description, actions);
+    elements.settingsDailyTaskCreationArea.appendChild(card);
+  }
+
+  function renderHabitCreationCard() {
+    elements.settingsHabitCreationArea.innerHTML = "";
+    if (!isHabitCreationOpen) return;
+
+    const card = document.createElement("article");
+    card.className = "work-card creation-card";
+
+    const title = document.createElement("input");
+    title.placeholder = "Habit title";
+
+    const day = document.createElement("select");
+    [
+      [1, "Monday"],
+      [2, "Tuesday"],
+      [3, "Wednesday"],
+      [4, "Thursday"],
+      [5, "Friday"],
+      [6, "Saturday"],
+      [0, "Sunday"],
+    ].forEach(([value, label]) => {
+      const opt = document.createElement("option");
+      opt.value = String(value);
+      opt.textContent = label;
+      day.appendChild(opt);
+    });
+
+    const time = document.createElement("input");
+    time.type = "time";
+    time.value = "09:00";
+
+    const description = document.createElement("input");
+    description.placeholder = "Description optional";
+
+    const actions = document.createElement("div");
+    actions.className = "item-actions";
+
+    const createBtn = document.createElement("button");
+    createBtn.textContent = "Create";
+    createBtn.addEventListener("click", async () => {
+      try {
+        await createHabit({
+          title: title.value,
+          dayOfWeek: Number(day.value),
+          time: time.value,
+          condition: description.value,
+        });
+        isHabitCreationOpen = false;
+        renderHabitCreationCard();
+      } catch (error) {
+        notifyError(error, "Failed to create habit");
+      }
+    });
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.className = "btn-muted";
+    cancelBtn.addEventListener("click", () => {
+      isHabitCreationOpen = false;
+      renderHabitCreationCard();
+    });
+
+    actions.append(createBtn, cancelBtn);
+    card.append(title, day, time, description, actions);
+    elements.settingsHabitCreationArea.appendChild(card);
+  }
+
+  function renderDailyList(tasks = {}) {
+    elements.settingsDailyTaskList.innerHTML = "";
+    Object.entries(tasks).forEach(([id, task]) => {
+      const li = document.createElement("li");
+      const card = document.createElement("article");
+      card.className = "work-card";
+
+      const title = document.createElement("h4");
+      title.className = "work-card-title";
+      title.textContent = task.title;
+
+      const meta = document.createElement("div");
+      meta.className = "work-card-meta";
+      const schedule = document.createElement("span");
+      schedule.textContent = `Daily ${task.schedule?.time || "--:--"}`;
+      meta.appendChild(schedule);
+
+      const actions = document.createElement("div");
+      actions.className = "item-actions";
+
+      const editBtn = document.createElement("button");
+      editBtn.textContent = "Edit";
+      editBtn.addEventListener("click", async () => {
+        const nextTitle = prompt("Title:", task.title || "");
+        if (nextTitle === null) return;
+        const nextTime = prompt("Time (HH:mm):", task.schedule?.time || "09:00");
+        if (nextTime === null) return;
+        const nextDescription = prompt("Description:", task.condition || "");
+        if (nextDescription === null) return;
+        try {
+          await updateDailyTask(id, {
+            title: nextTitle,
+            time: nextTime,
+            condition: nextDescription,
+          });
+        } catch (error) {
+          notifyError(error, "Failed to edit daily task");
+        }
+      });
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.textContent = "Delete";
+      deleteBtn.className = "btn-danger";
+      deleteBtn.addEventListener("click", () =>
+        deleteDailyTask(id).catch((error) => notifyError(error, "Failed to delete daily task")),
+      );
+
+      actions.append(editBtn, deleteBtn);
+      card.append(title, meta, actions);
+      li.appendChild(card);
+      elements.settingsDailyTaskList.appendChild(li);
+    });
+  }
+
+  function renderHabitList(habits = {}) {
+    elements.settingsHabitList.innerHTML = "";
+    Object.entries(habits).forEach(([id, habit]) => {
+      const li = document.createElement("li");
+      const card = document.createElement("article");
+      card.className = "work-card";
+
+      const title = document.createElement("h4");
+      title.className = "work-card-title";
+      title.textContent = habit.title;
+
+      const meta = document.createElement("div");
+      meta.className = "work-card-meta";
+      const schedule = document.createElement("span");
+      schedule.textContent = `D${habit.schedule?.dayOfWeek ?? "?"} ${habit.schedule?.time || "--:--"}`;
+      meta.appendChild(schedule);
+
+      const actions = document.createElement("div");
+      actions.className = "item-actions";
+
+      const editBtn = document.createElement("button");
+      editBtn.textContent = "Edit";
+      editBtn.addEventListener("click", async () => {
+        const nextTitle = prompt("Title:", habit.title || "");
+        if (nextTitle === null) return;
+        const nextDay = prompt("Day of week (0-6):", String(habit.schedule?.dayOfWeek ?? 1));
+        if (nextDay === null) return;
+        const nextTime = prompt("Time (HH:mm):", habit.schedule?.time || "09:00");
+        if (nextTime === null) return;
+        const nextDescription = prompt("Description:", habit.condition || "");
+        if (nextDescription === null) return;
+        try {
+          await updateHabit(id, {
+            title: nextTitle,
+            dayOfWeek: Number(nextDay),
+            time: nextTime,
+            condition: nextDescription,
+          });
+        } catch (error) {
+          notifyError(error, "Failed to edit habit");
+        }
+      });
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.textContent = "Delete";
+      deleteBtn.className = "btn-danger";
+      deleteBtn.addEventListener("click", () =>
+        deleteHabit(id).catch((error) => notifyError(error, "Failed to delete habit")),
+      );
+
+      actions.append(editBtn, deleteBtn);
+      card.append(title, meta, actions);
+      li.appendChild(card);
+      elements.settingsHabitList.appendChild(li);
+    });
+  }
+
+  elements.settingsAddDailyTaskBtn.addEventListener("click", () => {
+    isDailyCreationOpen = !isDailyCreationOpen;
+    renderDailyCreationCard();
+  });
+
+  elements.settingsAddHabitBtn.addEventListener("click", () => {
+    isHabitCreationOpen = !isHabitCreationOpen;
+    renderHabitCreationCard();
+  });
+
+  elements.resetTasksBtn.addEventListener("click", async () => {
+    if (!askDoubleConfirmation("reset tasks")) return;
+    try {
+      await resetTasksDomain();
+    } catch (error) {
+      notifyError(error, "Failed to reset tasks");
+    }
+  });
+
+  elements.resetStatsBtn.addEventListener("click", async () => {
+    if (!askDoubleConfirmation("reset stats")) return;
+    try {
+      await statsApi.reset();
+    } catch (error) {
+      notifyError(error, "Failed to reset stats");
+    }
+  });
+
+  elements.resetDatabaseBtn.addEventListener("click", async () => {
+    if (!askDoubleConfirmation("reset the entire database")) return;
+    try {
+      await resetEntireDatabase();
+    } catch (error) {
+      notifyError(error, "Failed to reset database");
+    }
+  });
+
+  return [
+    subscribeDailyTasks((tasks) => renderDailyList(tasks || {})),
+    subscribeHabits((habits) => renderHabitList(habits || {})),
+  ];
+}

--- a/src/modules/tasks.js
+++ b/src/modules/tasks.js
@@ -1,8 +1,7 @@
 import {
-  createDailyTask,
   completeDailyTask,
-  deleteDailyTask,
   subscribeDailyTasks,
+  resetDailyTasksForToday,
 } from "../services/dailyTaskService.js";
 import {
   createTask,
@@ -17,6 +16,7 @@ const STATUS_LABELS = {
   todo: "Todo",
   in_progress: "In Progress",
   done: "Done",
+  cancelled: "Cancelled",
 };
 
 const KANBAN_COLUMNS = [
@@ -26,6 +26,8 @@ const KANBAN_COLUMNS = [
   { key: "done", elementKey: "kanbanDone" },
 ];
 
+const STATUS_SEQUENCE = ["backlog", "todo", "in_progress", "done"];
+
 function isBoardTask(task) {
   return task && task.type !== "daily" && task.type !== "habit";
 }
@@ -34,127 +36,130 @@ function formatDate(ts) {
   return ts ? new Date(ts).toLocaleString() : "-";
 }
 
-function takeCreationSlot(owner) {
-  if (window.__activeCreationCardOwner && window.__activeCreationCardOwner !== owner) {
-    return false;
-  }
-  window.__activeCreationCardOwner = owner;
-  return true;
+function statusLabel(status, completed) {
+  if (status) return status;
+  return completed ? "done" : "backlog";
 }
 
-function releaseCreationSlot(owner) {
-  if (window.__activeCreationCardOwner === owner) {
-    window.__activeCreationCardOwner = null;
-  }
-}
-
-function makeCard({ title, description = "", metadata = [], actions = [] }) {
+function makeTrackingCard({ title, time, isDoneToday, onComplete }) {
   const card = document.createElement("article");
   card.className = "work-card";
 
   const heading = document.createElement("h4");
   heading.className = "work-card-title";
   heading.textContent = title;
-  card.appendChild(heading);
 
-  if (description) {
-    const desc = document.createElement("p");
-    desc.className = "work-card-description";
-    desc.textContent = description;
-    card.appendChild(desc);
-  }
+  const timeText = document.createElement("p");
+  timeText.className = "work-card-time";
+  timeText.textContent = time || "--:--";
 
-  const meta = document.createElement("div");
-  meta.className = "work-card-meta";
-  metadata.forEach((item) => {
-    const tag = document.createElement("span");
-    tag.textContent = item;
-    meta.appendChild(tag);
-  });
-  card.appendChild(meta);
+  const actions = document.createElement("div");
+  actions.className = "item-actions";
 
-  if (actions.length) {
-    const actionWrap = document.createElement("div");
-    actionWrap.className = "item-actions";
-    actions.forEach(({ label, onClick, className, type = "button" }) => {
-      const btn = document.createElement("button");
-      btn.type = type;
-      btn.textContent = label;
-      btn.className = className || "";
-      btn.addEventListener("click", onClick);
-      actionWrap.appendChild(btn);
-    });
-    card.appendChild(actionWrap);
-  }
+  const completeBtn = document.createElement("button");
+  completeBtn.textContent = isDoneToday ? "Completed" : "Complete";
+  completeBtn.className = isDoneToday ? "btn-muted" : "";
+  completeBtn.addEventListener("click", onComplete);
 
+  actions.appendChild(completeBtn);
+  card.append(heading, timeText, actions);
   return card;
 }
 
-function statusLabel(status, completed) {
-  if (status) return status;
-  return completed ? "done" : "backlog";
+function makeBoardCard({ task, taskId, onMove }) {
+  const status = statusLabel(task.status, task.completed);
+  const card = document.createElement("article");
+  card.className = "work-card kanban-card";
+  card.draggable = true;
+  card.dataset.taskId = taskId;
+
+  const heading = document.createElement("h4");
+  heading.className = "work-card-title";
+  heading.textContent = task.title;
+
+  const statusMeta = document.createElement("div");
+  statusMeta.className = "work-card-meta";
+  const badge = document.createElement("span");
+  badge.textContent = `[${STATUS_LABELS[status] || status}]`;
+  statusMeta.appendChild(badge);
+
+  const created = document.createElement("p");
+  created.className = "work-card-time";
+  created.textContent = `Created: ${formatDate(task.createdAt)}`;
+
+  const arrows = document.createElement("div");
+  arrows.className = "kanban-arrows";
+
+  const prev = document.createElement("button");
+  prev.textContent = "←";
+  prev.type = "button";
+  prev.className = "btn-muted";
+
+  const next = document.createElement("button");
+  next.textContent = "→";
+  next.type = "button";
+  next.className = "btn-muted";
+
+  const index = STATUS_SEQUENCE.indexOf(status);
+  prev.disabled = index <= 0;
+  next.disabled = index === -1 || index >= STATUS_SEQUENCE.length - 1;
+
+  prev.addEventListener("click", () => {
+    if (index <= 0) return;
+    onMove(STATUS_SEQUENCE[index - 1]);
+  });
+  next.addEventListener("click", () => {
+    if (index === -1 || index >= STATUS_SEQUENCE.length - 1) return;
+    onMove(STATUS_SEQUENCE[index + 1]);
+  });
+
+  arrows.append(prev, next);
+  card.append(heading, statusMeta, created, arrows);
+
+  return card;
 }
 
 export function initTasks(elements, notifyError) {
   let taskMap = {};
   let dailyTasksById = {};
   let boardDropBound = false;
-  let isDailyCreationOpen = false;
+  let activeDailyTab = "active";
 
-  function renderDailyCreationCard() {
-    elements.dailyTaskCreationArea.innerHTML = "";
+  function updateTabState(tabsRoot, activeTab) {
+    tabsRoot.querySelectorAll("button[data-tab]").forEach((btn) => {
+      btn.classList.toggle("is-active", btn.dataset.tab === activeTab);
+    });
+  }
 
-    if (!isDailyCreationOpen) return;
+  function renderDailyTracking() {
+    elements.dailyTaskList.innerHTML = "";
+    const rows = Object.entries(dailyTasksById);
+    const today = new Date().toDateString();
+    let completedCount = 0;
 
-    const card = document.createElement("article");
-    card.className = "work-card creation-card";
+    rows.forEach(([id, task]) => {
+      const isDoneToday = task.lastCompleted === today;
+      if (isDoneToday) completedCount += 1;
 
-    const title = document.createElement("input");
-    title.type = "text";
-    title.placeholder = "Daily task title";
+      const hiddenByTab =
+        (activeDailyTab === "active" && isDoneToday) ||
+        (activeDailyTab === "completed" && !isDoneToday);
+      if (hiddenByTab) return;
 
-    const time = document.createElement("input");
-    time.type = "time";
-    time.value = "09:00";
-
-    const desc = document.createElement("input");
-    desc.type = "text";
-    desc.placeholder = "Description optional";
-
-    const actions = document.createElement("div");
-    actions.className = "item-actions";
-
-    const createBtn = document.createElement("button");
-    createBtn.textContent = "Create";
-    createBtn.addEventListener("click", async () => {
-      try {
-        await createDailyTask({
-          title: title.value,
-          time: time.value || "09:00",
-          condition: desc.value,
-        });
-        isDailyCreationOpen = false;
-        releaseCreationSlot("daily");
-        renderDailyCreationCard();
-      } catch (error) {
-        notifyError(error, "Failed to create daily task");
-      }
+      const li = document.createElement("li");
+      li.appendChild(
+        makeTrackingCard({
+          title: task.title,
+          time: task.schedule?.time,
+          isDoneToday,
+          onComplete: () =>
+            completeDailyTask(id).catch((e) => notifyError(e, "Failed to complete daily task")),
+        }),
+      );
+      elements.dailyTaskList.appendChild(li);
     });
 
-    const cancelBtn = document.createElement("button");
-    cancelBtn.textContent = "Cancel";
-    cancelBtn.className = "btn-muted";
-    cancelBtn.addEventListener("click", () => {
-      isDailyCreationOpen = false;
-      releaseCreationSlot("daily");
-      renderDailyCreationCard();
-    });
-
-    actions.appendChild(createBtn);
-    actions.appendChild(cancelBtn);
-    card.append(title, time, desc, actions);
-    elements.dailyTaskCreationArea.appendChild(card);
-    title.focus();
+    elements.dailyProgressText.textContent = `${completedCount}/${rows.length} completed`;
   }
 
   function renderKanban(tasks) {
@@ -175,17 +180,17 @@ export function initTasks(elements, notifyError) {
       if (!bucket) return;
 
       const li = document.createElement("li");
-      const card = makeCard({
-        title: task.title,
-        description: task.description,
-        metadata: [
-          `Status: ${STATUS_LABELS[status] || status}`,
-          `Created: ${formatDate(task.createdAt)}`,
-        ],
+      const card = makeBoardCard({
+        task,
+        taskId: id,
+        onMove: async (nextStatus) => {
+          try {
+            await updateTask(id, { status: nextStatus });
+          } catch (error) {
+            notifyError(error, "Failed to update task status");
+          }
+        },
       });
-      card.draggable = true;
-      card.dataset.taskId = id;
-      card.classList.add("kanban-card");
       card.addEventListener("dragstart", (event) => {
         event.dataTransfer.setData("text/plain", id);
       });
@@ -263,49 +268,7 @@ export function initTasks(elements, notifyError) {
   function loadDailyTasks() {
     return subscribeDailyTasks((tasks) => {
       dailyTasksById = tasks || {};
-      elements.dailyTaskList.innerHTML = "";
-      const rows = Object.entries(dailyTasksById);
-      let completedCount = 0;
-      const today = new Date().toDateString();
-
-      rows.forEach(([id, task]) => {
-        const isDoneToday = task.lastCompleted === today;
-        if (isDoneToday) completedCount += 1;
-
-        const li = document.createElement("li");
-        li.appendChild(
-          makeCard({
-            title: task.title,
-            description: task.condition || "",
-            metadata: [
-              `Schedule: daily ${task.schedule?.time || "--:--"}`,
-              `Created: ${formatDate(task.createdAt)}`,
-              `Completed: ${task.completedAt ? formatDate(task.completedAt) : "-"}`,
-            ],
-            actions: [
-              {
-                label: "Complete",
-                className: isDoneToday ? "btn-muted" : "",
-                onClick: () =>
-                  completeDailyTask(id).catch((e) =>
-                    notifyError(e, "Failed to complete daily task"),
-                  ),
-              },
-              {
-                label: "Delete",
-                className: "btn-danger",
-                onClick: () =>
-                  deleteDailyTask(id).catch((e) =>
-                    notifyError(e, "Failed to delete daily task"),
-                  ),
-              },
-            ],
-          }),
-        );
-        elements.dailyTaskList.appendChild(li);
-      });
-
-      elements.dailyProgressText.textContent = `${completedCount}/${rows.length} completed`;
+      renderDailyTracking();
     });
   }
 
@@ -325,64 +288,106 @@ export function initTasks(elements, notifyError) {
         .forEach(([id, task]) => {
           const status = statusLabel(task.status, task.completed);
           const li = document.createElement("li");
-          li.appendChild(
-            makeCard({
-              title: task.title,
-              description: task.description,
-              metadata: [
-                `Status: ${STATUS_LABELS[status] || status}`,
-                `Created: ${formatDate(task.createdAt)}`,
-                `Completed: ${task.completedAt ? formatDate(task.completedAt) : "-"}`,
-              ],
-              actions: [
-                {
-                  label: "Complete",
-                  className: task.completed ? "btn-muted" : "",
-                  onClick: () => completeTask(id, task),
-                },
-                { label: "Edit", onClick: () => editTask(id, task) },
-                {
-                  label: "Delete",
-                  className: "btn-danger",
-                  onClick: () =>
-                    deleteTask(id).catch((e) => notifyError(e, "Failed to delete task")),
-                },
-              ],
-            }),
-          );
+
+          const card = document.createElement("article");
+          card.className = "work-card";
+          const h = document.createElement("h4");
+          h.className = "work-card-title";
+          h.textContent = task.title;
+          const meta = document.createElement("div");
+          meta.className = "work-card-meta";
+          [
+            `Status: ${STATUS_LABELS[status] || status}`,
+            `Created: ${formatDate(task.createdAt)}`,
+            `Completed: ${task.completedAt ? formatDate(task.completedAt) : "-"}`,
+          ].forEach((m) => {
+            const s = document.createElement("span");
+            s.textContent = m;
+            meta.appendChild(s);
+          });
+
+          const actions = document.createElement("div");
+          actions.className = "item-actions";
+          [
+            {
+              label: "Complete",
+              className: task.completed ? "btn-muted" : "",
+              onClick: () => completeTask(id, task),
+            },
+            { label: "Edit", onClick: () => editTask(id, task) },
+            {
+              label: "Delete",
+              className: "btn-danger",
+              onClick: () => deleteTask(id).catch((e) => notifyError(e, "Failed to delete task")),
+            },
+            {
+              label: "Cancel",
+              className: "btn-muted",
+              onClick: () =>
+                updateTask(id, { status: "cancelled" }).catch((e) =>
+                  notifyError(e, "Failed to cancel task"),
+                ),
+            },
+          ].forEach(({ label, className, onClick }) => {
+            const btn = document.createElement("button");
+            btn.textContent = label;
+            btn.className = className || "";
+            btn.addEventListener("click", onClick);
+            actions.appendChild(btn);
+          });
+
+          card.append(h, meta, actions);
+          li.appendChild(card);
           elements.taskList.appendChild(li);
         });
 
       const grouped = {
-        backlog: taskRows
-          .filter(([, task]) => statusLabel(task.status, task.completed) === "backlog")
-          .sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0)),
-        todo: taskRows
-          .filter(([, task]) => statusLabel(task.status, task.completed) === "todo")
-          .sort(([, a], [, b]) => (a.createdAt || 0) - (b.createdAt || 0)),
-        in_progress: taskRows
-          .filter(([, task]) => statusLabel(task.status, task.completed) === "in_progress")
-          .sort(([, a], [, b]) => (a.createdAt || 0) - (b.createdAt || 0)),
-        done: taskRows
-          .filter(([, task]) => statusLabel(task.status, task.completed) === "done")
-          .sort(([, a], [, b]) => (a.createdAt || 0) - (b.createdAt || 0)),
+        backlog: taskRows.filter(
+          ([, task]) => statusLabel(task.status, task.completed) === "backlog",
+        ),
+        todo: taskRows.filter(([, task]) => statusLabel(task.status, task.completed) === "todo"),
+        in_progress: taskRows.filter(
+          ([, task]) => statusLabel(task.status, task.completed) === "in_progress",
+        ),
+        done: taskRows.filter(([, task]) => statusLabel(task.status, task.completed) === "done"),
       };
 
       renderKanban(Object.fromEntries(Object.values(grouped).flat()));
     });
   }
 
-  elements.addTaskBtn.addEventListener("click", addTask);
-  elements.addDailyTaskBtn.addEventListener("click", () => {
-    if (!isDailyCreationOpen && !takeCreationSlot("daily")) return;
-    if (isDailyCreationOpen) {
-      isDailyCreationOpen = false;
-      releaseCreationSlot("daily");
-    } else {
-      isDailyCreationOpen = true;
+  function scheduleDailyReset() {
+    async function runReset() {
+      try {
+        await resetDailyTasksForToday();
+      } catch (error) {
+        notifyError(error, "Failed to reset daily tracking");
+      }
     }
-    renderDailyCreationCard();
+
+    const now = new Date();
+    const nextMidnight = new Date(now);
+    nextMidnight.setHours(24, 0, 0, 0);
+    const timeout = nextMidnight.getTime() - now.getTime();
+
+    setTimeout(() => {
+      runReset();
+      setInterval(runReset, 24 * 60 * 60 * 1000);
+    }, timeout);
+
+    runReset();
+  }
+
+  elements.addTaskBtn.addEventListener("click", addTask);
+  elements.dailyTrackingTabs.addEventListener("click", (event) => {
+    const button = event.target.closest("button[data-tab]");
+    if (!button) return;
+    activeDailyTab = button.dataset.tab;
+    updateTabState(elements.dailyTrackingTabs, activeDailyTab);
+    renderDailyTracking();
   });
+
+  scheduleDailyReset();
 
   return [loadDailyTasks(), loadTasks()];
 }

--- a/src/services/dailyTaskService.js
+++ b/src/services/dailyTaskService.js
@@ -14,6 +14,16 @@ export async function createDailyTask({ title, time, condition = "" }) {
   );
 }
 
+export async function updateDailyTask(taskId, updates = {}) {
+  const payload = { updatedAt: Date.now() };
+  if (updates.title !== undefined) payload.title = String(updates.title || "").trim();
+  if (updates.condition !== undefined) payload.condition = String(updates.condition || "").trim();
+  if (updates.time !== undefined) {
+    payload.schedule = { mode: "daily", time: String(updates.time || "09:00") };
+  }
+  return dailyTasksApi.patchById(taskId, payload);
+}
+
 export async function completeDailyTask(taskId) {
   const task = await dailyTasksApi.getById(taskId);
   if (!task) return;
@@ -30,6 +40,20 @@ export async function completeDailyTask(taskId) {
     updatedAt: Date.now(),
   });
   recordDailyTaskCompletion(task);
+}
+
+export async function resetDailyTasksForToday() {
+  const tasks = (await dailyTasksApi.list()) || {};
+  const today = new Date().toDateString();
+  const work = Object.entries(tasks).map(([id, task]) => {
+    if (!task || task.lastCompleted === today) return Promise.resolve();
+    return dailyTasksApi.patchById(id, {
+      status: "todo",
+      completedAt: null,
+      updatedAt: Date.now(),
+    });
+  });
+  await Promise.all(work);
 }
 
 export async function deleteDailyTask(taskId) {

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -27,10 +27,38 @@ export async function createHabit({ title, dayOfWeek, time, condition = "" }) {
   );
 }
 
+export async function updateHabit(habitId, updates = {}) {
+  const payload = { updatedAt: Date.now() };
+  if (updates.title !== undefined) payload.title = String(updates.title || "").trim();
+  if (updates.condition !== undefined) payload.condition = String(updates.condition || "").trim();
+  if (updates.dayOfWeek !== undefined || updates.time !== undefined) {
+    payload.schedule = {
+      mode: "weekly",
+      dayOfWeek: Number(updates.dayOfWeek ?? 1),
+      time: String(updates.time || "09:00"),
+    };
+  }
+  return habitsApi.patchById(habitId, payload);
+}
+
 export async function completeHabit(habitId, habit) {
   const nextState = nextHabitState(habit);
   await habitsApi.patchById(habitId, nextState);
   recordHabitCompletion(habit);
+}
+
+export async function resetHabitsForToday() {
+  const habits = (await habitsApi.list()) || {};
+  const today = new Date().toDateString();
+  const work = Object.entries(habits).map(([id, habit]) => {
+    if (!habit || habit.lastCompleted === today) return Promise.resolve();
+    return habitsApi.patchById(id, {
+      status: "todo",
+      completedAt: null,
+      updatedAt: Date.now(),
+    });
+  });
+  await Promise.all(work);
 }
 
 export async function deleteHabit(habitId) {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -7,6 +7,8 @@ import { initFinance } from "../modules/finance.js";
 import { initCalendar } from "../modules/calendar.js";
 import { initFocus } from "../modules/focus.js";
 import { initNotes } from "../modules/notes.js";
+import { initSettings } from "../modules/settings.js";
+import { createNote } from "../services/noteService.js";
 
 const elements = {
   atk: document.getElementById("atk"),
@@ -37,6 +39,12 @@ const elements = {
     wis: document.getElementById("quick-wis"),
     levelExp: document.getElementById("quick-level-exp"),
   },
+  currentDayOfWeek: document.getElementById("currentDayOfWeek"),
+  currentDate: document.getElementById("currentDate"),
+  currentTime: document.getElementById("currentTime"),
+  quickNoteInput: document.getElementById("quickNoteInput"),
+  quickNoteClearBtn: document.getElementById("quickNoteClearBtn"),
+  quickNotePushBtn: document.getElementById("quickNotePushBtn"),
   todaySummaryList: document.getElementById("todaySummaryList"),
   todayEventsList: document.getElementById("todayEventsList"),
   sidebarNav: document.getElementById("sidebarNav"),
@@ -44,13 +52,20 @@ const elements = {
   mainViews: document.querySelectorAll(".main-view"),
   calendarTabs: document.getElementById("calendarTabs"),
   calendarModes: document.querySelectorAll(".calendar-mode"),
-  dailyTaskCreationArea: document.getElementById("dailyTaskCreationArea"),
-  addDailyTaskBtn: document.getElementById("addDailyTaskBtn"),
   dailyTaskList: document.getElementById("dailyTaskList"),
   dailyProgressText: document.getElementById("dailyProgressText"),
-  habitCreationArea: document.getElementById("habitCreationArea"),
-  addHabitBtn: document.getElementById("addHabitBtn"),
+  dailyTrackingTabs: document.getElementById("dailyTrackingTabs"),
+  habitTrackingTabs: document.getElementById("habitTrackingTabs"),
   habitList: document.getElementById("habitList"),
+  settingsAddDailyTaskBtn: document.getElementById("settingsAddDailyTaskBtn"),
+  settingsDailyTaskCreationArea: document.getElementById("settingsDailyTaskCreationArea"),
+  settingsDailyTaskList: document.getElementById("settingsDailyTaskList"),
+  settingsAddHabitBtn: document.getElementById("settingsAddHabitBtn"),
+  settingsHabitCreationArea: document.getElementById("settingsHabitCreationArea"),
+  settingsHabitList: document.getElementById("settingsHabitList"),
+  resetTasksBtn: document.getElementById("resetTasksBtn"),
+  resetStatsBtn: document.getElementById("resetStatsBtn"),
+  resetDatabaseBtn: document.getElementById("resetDatabaseBtn"),
   taskInput: document.getElementById("taskInput"),
   taskDescriptionInput: document.getElementById("taskDescriptionInput"),
   taskConditionInput: document.getElementById("taskConditionInput"),
@@ -141,6 +156,37 @@ function mirrorQuickStats(extra = {}) {
 
   const focusToday = extra.focusToday ?? 0;
   elements.quickStats.levelExp.textContent = `${elements.level.textContent} / ${elements.exp.textContent} • Focus ${focusToday}`;
+}
+
+function renderDateTime() {
+  const now = new Date();
+  elements.currentDayOfWeek.textContent = now.toLocaleDateString(undefined, { weekday: "long" });
+  elements.currentDate.textContent = now.toISOString().slice(0, 10);
+  elements.currentTime.textContent = now.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function initDateTime() {
+  renderDateTime();
+  setInterval(renderDateTime, 60 * 1000);
+}
+
+function initQuickNote() {
+  elements.quickNoteClearBtn.addEventListener("click", () => {
+    elements.quickNoteInput.value = "";
+  });
+
+  elements.quickNotePushBtn.addEventListener("click", async () => {
+    if (!elements.quickNoteInput.value.trim()) return;
+    try {
+      await createNote(elements.quickNoteInput.value);
+      elements.quickNoteInput.value = "";
+    } catch (error) {
+      notifyError(error, "Failed to push quick note");
+    }
+  });
 }
 
 function renderTodaySummary() {
@@ -252,10 +298,13 @@ function init() {
   initStats(elements);
   initTasks(elements, notifyError);
   initHabits(elements, notifyError);
+  initSettings(elements, notifyError);
   initNotes(elements, notifyError);
   initFinance(elements, notifyError);
   initFocus(elements, notifyError);
   initCalendar(elements, notifyError);
+  initQuickNote();
+  initDateTime();
   initActivityLog();
   observeDashboardData();
 }

--- a/style.css
+++ b/style.css
@@ -271,3 +271,46 @@ button {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.settings-grid {
+  display: grid;
+  gap: 12px;
+}
+.tracking-tabs {
+  display: flex;
+  gap: 6px;
+  margin: 8px 0;
+}
+.tracking-tabs button {
+  width: auto;
+}
+.tracking-tabs button.is-active {
+  background: #364966;
+}
+.work-card-time {
+  margin: 8px 0;
+  font-size: 13px;
+  color: #bac7db;
+}
+.kanban-arrows {
+  display: none;
+  gap: 6px;
+  margin-top: 6px;
+}
+.kanban-arrows button {
+  width: auto;
+}
+.kanban-card:hover .kanban-arrows {
+  display: flex;
+}
+.date-time-day {
+  font-size: 18px;
+  font-weight: 700;
+}
+.date-time-clock {
+  font-size: 24px;
+  font-weight: 700;
+}
+.settings-reset-actions {
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
### Motivation
- Reduce UI clutter by moving Daily/Habit creation and configuration out of the Task panel into a dedicated Settings area so tracking surfaces show only status and completion controls. 
- Provide safer database management (scoped resets + full reset) and clearer task workflow states for better user control and clarity.

### Description
- Introduced a new Settings main view and `src/modules/settings.js` to host Daily Task Setup, Habit Setup and Database Controls with two-step confirmation flows for resets. 
- Moved Daily/Habit creation/edit/delete to Settings and simplified tracking cards in the task panel to title/time/complete button with Active/Completed/All tabs for both Daily and Habits. 
- Implemented daily reset scheduling (local midnight) for daily tasks and habits by adding `resetDailyTasksForToday` and `resetHabitsForToday` in services and wiring a midnight `setTimeout`/`setInterval` runner. 
- Added `cancelled` status support in `src/core/workItemModel.js`, visual status badges and hover arrow movement (← / →) fallback for Kanban card status changes, while preserving drag-and-drop. 
- Extended firebase service API with list/read helpers and reset helpers (`stats.reset`, `dailyTasks.list`, `habits.list`, `resetTasksDomain`, `resetEntireDatabase`) used by Settings controls. 
- Added Dashboard Date/Time module (updates every 60s) and a Quick Note UI that keeps local state until pushed to notes via `noteService.createNote()`. 

### Testing
- Ran `npx prettier --write` to format modified files and it completed successfully. 
- Ran `npm run lint` and fixed issues until lint passed successfully. 
- Ran `npm test` and all unit tests passed (`5` tests, `0` failures). 
- Performed a manual UI verification by serving the app (`python -m http.server`) and capturing a Playwright screenshot of the updated dashboard which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b273bacc448323803ec70d9bdf1c63)