### PR TITLE
Export `statsApi` from firebase barrel to fix import error

### DIFF
--- a/src/core/firebase.js
+++ b/src/core/firebase.js
@@ -2,6 +2,7 @@ export {
   getPaths,
   subscribe,
   unsubscribeAll,
+  statsApi,
   tasksApi,
   notesApi,
   financeApi,


### PR DESCRIPTION
### Motivation
- The runtime import error in `settings.js` (`does not provide an export named 'statsApi'`) was caused by `statsApi` missing from the `src/core/firebase.js` re-exports.

### Description
- Add `statsApi` to the re-exports in `src/core/firebase.js` so it is exported from the barrel (`export { ..., statsApi, ... } from "./firebaseService.js"`).

### Testing
- Ran the test suite with `npm test -- --runInBand` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2779253288323aeff2194f2d82ca7)