### PR TITLE
Restructure dashboard layout and consolidate tasks into tracking panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
         <h2>Mode</h2>
         <nav class="sidebar-nav" id="sidebarNav">
           <button class="nav-btn is-active" data-view="dashboard" title="Dashboard">🏠</button>
-          <button class="nav-btn" data-view="tasks" title="Tasks">✅</button>
           <button class="nav-btn" data-view="calendar" title="Calendar">📅</button>
           <button class="nav-btn" data-view="notes" title="Notes">📝</button>
           <button class="nav-btn" data-view="settings" title="Settings">⚙️</button>
@@ -25,32 +24,18 @@
 
       <main class="main-area">
         <section class="main-view is-active" data-view="dashboard">
-          <section class="card">
-            <h2>Quick Stats (EXP / Focus today)</h2>
-            <div class="quick-stats-grid">
-              <div><span>ATK</span><strong id="quick-atk">0</strong></div>
-              <div><span>INT</span><strong id="quick-int">0</strong></div>
-              <div><span>DISC</span><strong id="quick-disc">0</strong></div>
-              <div><span>CRE</span><strong id="quick-cre">0</strong></div>
-              <div><span>END</span><strong id="quick-end">0</strong></div>
-              <div><span>FOC</span><strong id="quick-foc">0</strong></div>
-              <div><span>WIS</span><strong id="quick-wis">0</strong></div>
-              <div><span>LVL / EXP</span><strong id="quick-level-exp">1 / 0</strong></div>
-            </div>
-          </section>
-
-          <section class="card" id="dateTimeCard">
+          <section class="card dashboard-card dashboard-compact" id="dateTimeCard">
             <h2>Date & Time</h2>
             <div class="date-time-day" id="currentDayOfWeek">-</div>
             <div id="currentDate">-</div>
             <div class="date-time-clock" id="currentTime">-</div>
           </section>
 
-          <section class="card" id="quickNoteCard">
+          <section class="card dashboard-card dashboard-compact" id="quickNoteCard">
             <h2>Quick Note</h2>
             <textarea
               id="quickNoteInput"
-              placeholder="Temporary scratch note (not saved until you push)..."
+              placeholder="Saved automatically. Push to Notes when ready."
             ></textarea>
             <div class="item-actions">
               <button id="quickNoteClearBtn" class="btn-muted">Clear</button>
@@ -58,45 +43,19 @@
             </div>
           </section>
 
-          <section class="card">
+          <section class="card dashboard-card">
             <h2>Today Summary</h2>
             <ul id="todaySummaryList"></ul>
           </section>
 
-          <section class="card">
+          <section class="card dashboard-card">
             <h2>Today's Calendar Events</h2>
             <ul id="todayEventsList"></ul>
           </section>
 
-          <section class="card activity">
+          <section class="card dashboard-card dashboard-wide activity">
             <h2>Recent Activity</h2>
             <ul id="activityLogList"></ul>
-          </section>
-        </section>
-
-        <section class="main-view" data-view="tasks">
-          <section class="card">
-            <h2>Tasks</h2>
-            <button id="toggleTaskCreationBtn">Create Task</button>
-            <div id="taskCreationPanel" class="task-creation-panel">
-              <input type="text" id="taskInput" placeholder="Task title" />
-              <textarea id="taskDescriptionInput" placeholder="Task description"></textarea>
-              <input type="text" id="taskConditionInput" placeholder="Condition" />
-              <select id="taskTypeInput">
-                <option value="work">work</option>
-                <option value="personal">personal</option>
-                <option value="study">study</option>
-                <option value="task">task</option>
-              </select>
-              <select id="taskPriorityInput">
-                <option value="low">low</option>
-                <option value="medium">medium</option>
-                <option value="high">high</option>
-              </select>
-              <input type="datetime-local" id="taskScheduleInput" />
-              <button id="addTaskBtn">Save Task</button>
-            </div>
-            <ul id="taskList"></ul>
           </section>
         </section>
 
@@ -268,6 +227,30 @@
 
       <aside class="task-panel card">
         <h2>Tracking</h2>
+
+        <section>
+          <h3>Tasks</h3>
+          <button id="toggleTaskCreationBtn">Create Task</button>
+          <div id="taskCreationPanel" class="task-creation-panel">
+            <input type="text" id="taskInput" placeholder="Task title" />
+            <textarea id="taskDescriptionInput" placeholder="Task description"></textarea>
+            <input type="text" id="taskConditionInput" placeholder="Condition" />
+            <select id="taskTypeInput">
+              <option value="work">work</option>
+              <option value="personal">personal</option>
+              <option value="study">study</option>
+              <option value="task">task</option>
+            </select>
+            <select id="taskPriorityInput">
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+            </select>
+            <input type="datetime-local" id="taskScheduleInput" />
+            <button id="addTaskBtn">Save Task</button>
+          </div>
+          <ul id="taskList"></ul>
+        </section>
 
         <section>
           <h3>Daily Tasks <small id="dailyProgressText">0/0 completed</small></h3>

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -29,16 +29,6 @@ const elements = {
     foc: document.getElementById("bar-foc"),
     wis: document.getElementById("bar-wis"),
   },
-  quickStats: {
-    atk: document.getElementById("quick-atk"),
-    int: document.getElementById("quick-int"),
-    disc: document.getElementById("quick-disc"),
-    cre: document.getElementById("quick-cre"),
-    end: document.getElementById("quick-end"),
-    foc: document.getElementById("quick-foc"),
-    wis: document.getElementById("quick-wis"),
-    levelExp: document.getElementById("quick-level-exp"),
-  },
   currentDayOfWeek: document.getElementById("currentDayOfWeek"),
   currentDate: document.getElementById("currentDate"),
   currentTime: document.getElementById("currentTime"),
@@ -149,15 +139,6 @@ function initNavigation() {
   });
 }
 
-function mirrorQuickStats(extra = {}) {
-  ["atk", "int", "disc", "cre", "end", "foc", "wis"].forEach((key) => {
-    elements.quickStats[key].textContent = elements[key].textContent;
-  });
-
-  const focusToday = extra.focusToday ?? 0;
-  elements.quickStats.levelExp.textContent = `${elements.level.textContent} / ${elements.exp.textContent} • Focus ${focusToday}`;
-}
-
 function renderDateTime() {
   const now = new Date();
   elements.currentDayOfWeek.textContent = now.toLocaleDateString(undefined, { weekday: "long" });
@@ -174,8 +155,19 @@ function initDateTime() {
 }
 
 function initQuickNote() {
+  const storageKey = "quick-note-draft";
+  const savedDraft = localStorage.getItem(storageKey);
+  if (savedDraft) {
+    elements.quickNoteInput.value = savedDraft;
+  }
+
+  elements.quickNoteInput.addEventListener("input", () => {
+    localStorage.setItem(storageKey, elements.quickNoteInput.value);
+  });
+
   elements.quickNoteClearBtn.addEventListener("click", () => {
     elements.quickNoteInput.value = "";
+    localStorage.removeItem(storageKey);
   });
 
   elements.quickNotePushBtn.addEventListener("click", async () => {
@@ -183,6 +175,7 @@ function initQuickNote() {
     try {
       await createNote(elements.quickNoteInput.value);
       elements.quickNoteInput.value = "";
+      localStorage.removeItem(storageKey);
     } catch (error) {
       notifyError(error, "Failed to push quick note");
     }
@@ -235,7 +228,6 @@ function renderTodayEvents() {
 
 function observeDashboardData() {
   const observer = new MutationObserver(() => {
-    mirrorQuickStats();
     renderTodaySummary();
     renderTodayEvents();
   });
@@ -259,14 +251,11 @@ function observeDashboardData() {
     observer.observe(target, { childList: true, subtree: true, characterData: true });
   });
 
-  mirrorQuickStats();
   renderTodaySummary();
   renderTodayEvents();
 }
 
 function initActivityLog() {
-  const today = new Date().toDateString();
-
   return activityApi.subscribe((entries) => {
     elements.activityLogList.innerHTML = "";
     if (!entries) return;
@@ -279,16 +268,6 @@ function initActivityLog() {
       elements.activityLogList.appendChild(li);
     });
 
-    const focusToday = sorted.filter((entry) => {
-      const sameDay = new Date(entry.createdAt || 0).toDateString() === today;
-      return (
-        String(entry.message || "")
-          .toLowerCase()
-          .includes("focus") && sameDay
-      );
-    }).length;
-
-    mirrorQuickStats({ focusToday });
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -44,20 +44,28 @@ body {
 .main-view.is-active {
   display: grid;
 }
-.quick-stats-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
+.main-view[data-view="dashboard"].is-active {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  align-items: start;
 }
-.quick-stats-grid div {
-  background: #111722;
-  padding: 8px;
-  border-radius: 8px;
-  display: flex;
-  justify-content: space-between;
+.dashboard-card {
+  grid-column: span 6;
+}
+.dashboard-card.dashboard-compact {
+  grid-column: span 4;
+}
+.dashboard-card.dashboard-wide {
+  grid-column: 1 / -1;
 }
 .task-panel {
   overflow: auto;
+}
+
+.task-panel > section {
+  margin-bottom: 14px;
+}
+.task-panel > section:last-child {
+  margin-bottom: 0;
 }
 ul {
   margin: 8px 0 0;
@@ -269,6 +277,27 @@ button {
   }
   .task-columns {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .main-view[data-view="dashboard"].is-active {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .dashboard-card,
+  .dashboard-card.dashboard-compact {
+    grid-column: span 1;
+  }
+  .dashboard-card.dashboard-wide {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 820px) {
+  .main-view[data-view="dashboard"].is-active {
+    grid-template-columns: 1fr;
+  }
+  .dashboard-card,
+  .dashboard-card.dashboard-compact,
+  .dashboard-card.dashboard-wide {
+    grid-column: 1;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Consolidate task UI by moving task creation and listing out of the dedicated Tasks view into the right-hand Tracking panel so tasks are always accessible while viewing the dashboard.  
- Remove the redundant Quick Stats dashboard block and simplify dashboard modules to make better use of horizontal space.  
- Make Quick Note persistent between sessions until explicitly pushed or cleared and reorganize the dashboard cards so small modules shrink and larger modules span more width for a balanced layout.

### Description
- Updated `index.html` to remove the standalone Tasks view and the Quick Stats block, and to add the task creation form and `#taskList` into the right-hand tracking panel; added dashboard card classes (`dashboard-card`, `dashboard-compact`, `dashboard-wide`).
- Implemented autosave for Quick Note in `src/ui/ui.js` using `localStorage` so the draft persists until `Push to Notes` or `Clear`, and removed DOM references and mirror logic for the removed Quick Stats block; adjusted dashboard observer calls accordingly.
- Reworked layout rules in `style.css` to add a responsive dashboard grid (`main-view[data-view="dashboard"]`) with card span rules and media queries so compact modules take less width and wide modules can span the full row.
- Adjusted UI initialization to keep behavior consistent with the new layout and ensured task creation toggle still opens the creation panel in the tracking sidebar; changed Quick Note placeholder text to reflect autosave behavior.

### Testing
- Ran `npm run lint` and it completed successfully with no lint errors.  
- Ran the test suite with `npm test` and all tests passed (all automated tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b28a6a4318832385161ee519ef005c)