### PR TITLE
Add dashboard web shortcuts, focus widget, finance lock, and calendar status/visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
           <button class="nav-btn" data-view="calendar" title="Calendar">📅</button>
           <button class="nav-btn" data-view="notes" title="Notes">📝</button>
           <button class="nav-btn" data-view="settings" title="Settings">⚙️</button>
-          <button class="nav-btn" data-view="focus" title="Focus">🎯</button>
           <button class="nav-btn" data-view="finance" title="Finance">💰</button>
           <button class="nav-btn" data-view="stats" title="Stats">📊</button>
         </nav>
@@ -51,6 +50,24 @@
           <section class="card dashboard-card">
             <h2>Today's Calendar Events</h2>
             <ul id="todayEventsList"></ul>
+          </section>
+
+          <section class="card dashboard-card">
+            <h2>Focus Session</h2>
+            <div class="focus-timer" id="focusDashboardTimer">00:00</div>
+            <div class="focus-controls focus-controls-dashboard">
+              <button id="focusDashboardStartBtn">Start</button>
+              <button id="focusDashboardStopBtn" class="btn-danger">Stop</button>
+            </div>
+            <div class="focus-dashboard-stats">
+              <span>Session Today: <strong id="focusSessionToday">0</strong></span>
+              <span>Total Time: <strong id="focusTotalTimeToday">0m</strong></span>
+            </div>
+          </section>
+
+          <section class="card dashboard-card">
+            <h2>Web Shortcuts</h2>
+            <div class="dashboard-shortcuts" id="webShortcutsContainer"></div>
           </section>
 
           <section class="card dashboard-card dashboard-wide activity">
@@ -138,20 +155,6 @@
                 </div>
               </section>
             </div>
-          </section>
-        </section>
-
-        <section class="main-view" data-view="focus">
-          <section class="card focus">
-            <h2>Focus Session</h2>
-            <div class="focus-controls">
-              <button data-duration="90">Start 90 min</button>
-              <button data-duration="120">Start 120 min</button>
-              <button id="cancelFocusBtn" class="btn-danger">Cancel Active</button>
-            </div>
-            <div class="focus-timer" id="focusTimer">00:00</div>
-            <h3>Sessions</h3>
-            <ul id="focusSessionList"></ul>
           </section>
         </section>
 
@@ -272,6 +275,18 @@
           <ul id="habitList"></ul>
         </section>
       </aside>
+    </div>
+
+    <div class="modal-backdrop" id="financeGuardModal" hidden>
+      <div class="modal-card">
+        <h3>Finance Password</h3>
+        <p>Enter password to unlock Finance tab.</p>
+        <input type="password" id="financePasswordInput" placeholder="Password" />
+        <div class="item-actions">
+          <button id="financeUnlockBtn">Unlock</button>
+          <button id="financeCancelBtn" class="btn-muted">Cancel</button>
+        </div>
+      </div>
     </div>
 
     <script type="module" src="./src/ui/ui.js"></script>

--- a/src/core/firebase.js
+++ b/src/core/firebase.js
@@ -11,6 +11,7 @@ export {
   focusApi,
   activityApi,
   calendarApi,
+  webShortcutsApi,
   resetTasksDomain,
   resetEntireDatabase,
 } from "./firebaseService.js";

--- a/src/core/firebaseService.js
+++ b/src/core/firebaseService.js
@@ -177,6 +177,13 @@ export const activityApi = {
   subscribe: (callback) => subscribe(PATHS.activityLog, callback),
 };
 
+export const webShortcutsApi = {
+  add: (shortcut) => create(PATHS.webShortcuts, shortcut),
+  subscribe: (callback) => subscribe(PATHS.webShortcuts, callback),
+  getById: (shortcutId) => read(`${PATHS.webShortcuts}/${shortcutId}`),
+  updateById: (shortcutId, value) => patch(`${PATHS.webShortcuts}/${shortcutId}`, value),
+  deleteById: (shortcutId) => destroy(`${PATHS.webShortcuts}/${shortcutId}`),
+};
 export const calendarApi = {
   addEvent: (event) => create(PATHS.calendarEvents, event),
   subscribeEvents: (callback) => subscribe(PATHS.calendarEvents, callback),

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -11,4 +11,5 @@ export const PATHS = Object.freeze({
   activityLog: "activityLog",
   calendar: "calendar",
   calendarEvents: "calendar/events",
+  webShortcuts: "webShortcuts",
 });

--- a/src/modules/calendar.js
+++ b/src/modules/calendar.js
@@ -1,6 +1,15 @@
 import { tasksApi, dailyTasksApi, habitsApi } from "../core/firebase.js";
 
 const WEEK_DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000;
+
+function toDayKey(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function getMonthLabel(date, viewMode) {
+  return `${viewMode.toUpperCase()} • ${date.toLocaleString([], { month: "long", year: "numeric" })}`;
+}
 
 function formatTimeRange(event) {
   const start = new Date(event.startAt);
@@ -9,12 +18,30 @@ function formatTimeRange(event) {
   return `${start.toLocaleTimeString([], options)}-${end.toLocaleTimeString([], options)}`;
 }
 
-function getMonthLabel(date, viewMode) {
-  return `${viewMode.toUpperCase()} • ${date.toLocaleString([], { month: "long", year: "numeric" })}`;
+function resolveStatus(event, now) {
+  if (event.completed) return "completed";
+  if ((event.taskTime || event.startAt) < now) return "fail";
+  return "pending";
 }
 
-function toDayKey(date) {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+function snapshotPrefix(status) {
+  if (status === "fail") return "● FAIL";
+  if (status === "completed") return "✔";
+  return "●";
+}
+
+function createStatusDot(status) {
+  const dot = document.createElement("span");
+  dot.className = `calendar-status-dot is-${status}`;
+  dot.textContent = "●";
+  return dot;
+}
+
+function parseTime(time = "09:00") {
+  const [h, m] = String(time)
+    .split(":")
+    .map((n) => Number(n || 0));
+  return { h, m };
 }
 
 function getDaysGrid(viewDate, viewMode) {
@@ -44,63 +71,58 @@ function getDaysGrid(viewDate, viewMode) {
   return cells;
 }
 
-function parseTime(time = "09:00") {
-  const [h, m] = String(time)
-    .split(":")
-    .map((n) => Number(n || 0));
-  return { h, m };
-}
-
-function rangeDayKeys(days) {
-  return new Set(days.filter(Boolean).map((d) => toDayKey(d)));
-}
-
 function scheduledItems(days, tasks, dailyTasks, habits) {
   const byDay = new Map();
-  const keys = rangeDayKeys(days);
+  const allowed = new Set(days.filter(Boolean).map((d) => toDayKey(d)));
 
-  const add = (dayKey, item) => {
-    if (!keys.has(dayKey)) return;
-    if (!byDay.has(dayKey)) byDay.set(dayKey, []);
-    byDay.get(dayKey).push({ ...item, readonly: true });
+  const add = (date, event) => {
+    const key = toDayKey(date);
+    if (!allowed.has(key)) return;
+    if (!byDay.has(key)) byDay.set(key, []);
+    byDay.get(key).push(event);
   };
 
-  Object.entries(tasks || {}).forEach(([id, task]) => {
+  Object.values(tasks || {}).forEach((task) => {
     const ts = task.schedule?.specificAt;
     if (!ts) return;
     const date = new Date(ts);
-    add(toDayKey(date), {
-      id: `task-${id}`,
-      kind: "task",
+    add(date, {
       title: task.title,
+      kind: "task",
       startAt: ts,
       endAt: ts + 30 * 60 * 1000,
+      taskTime: ts,
+      completed: Boolean(task.completed),
     });
   });
 
-  days.filter(Boolean).forEach((d) => {
-    Object.entries(dailyTasks || {}).forEach(([id, task]) => {
+  days.filter(Boolean).forEach((date) => {
+    Object.values(dailyTasks || {}).forEach((task) => {
       const { h, m } = parseTime(task.schedule?.time);
-      const startAt = new Date(d.getFullYear(), d.getMonth(), d.getDate(), h, m).getTime();
-      add(toDayKey(d), {
-        id: `daily-${id}-${toDayKey(d)}`,
-        kind: "daily",
+      const at = new Date(date.getFullYear(), date.getMonth(), date.getDate(), h, m).getTime();
+      const done = task.lastCompleted === date.toDateString();
+      add(date, {
         title: task.title,
-        startAt,
-        endAt: startAt + 30 * 60 * 1000,
+        kind: "daily",
+        startAt: at,
+        endAt: at + 30 * 60 * 1000,
+        taskTime: at,
+        completed: done,
       });
     });
 
-    Object.entries(habits || {}).forEach(([id, habit]) => {
-      if (Number(habit.schedule?.dayOfWeek) !== d.getDay()) return;
+    Object.values(habits || {}).forEach((habit) => {
+      if (Number(habit.schedule?.dayOfWeek) !== date.getDay()) return;
       const { h, m } = parseTime(habit.schedule?.time);
-      const startAt = new Date(d.getFullYear(), d.getMonth(), d.getDate(), h, m).getTime();
-      add(toDayKey(d), {
-        id: `habit-${id}-${toDayKey(d)}`,
-        kind: "habit",
+      const at = new Date(date.getFullYear(), date.getMonth(), date.getDate(), h, m).getTime();
+      const done = habit.lastCompleted === date.toDateString();
+      add(date, {
         title: habit.title,
-        startAt,
-        endAt: startAt + 30 * 60 * 1000,
+        kind: "habit",
+        startAt: at,
+        endAt: at + 30 * 60 * 1000,
+        taskTime: at,
+        completed: done,
       });
     });
   });
@@ -130,6 +152,8 @@ export function initCalendar(elements) {
 
     const gridDays = getDaysGrid(viewDate, viewMode);
     const byDay = scheduledItems(gridDays, tasksById, dailyTasksById, habitsById);
+    const now = Date.now();
+    const maxVisible = now + FOUR_DAYS_MS;
 
     elements.calendarGrid.innerHTML = "";
     elements.calendarGrid.style.gridTemplateColumns =
@@ -146,22 +170,32 @@ export function initCalendar(elements) {
       }
 
       const key = toDayKey(dayDate);
-      const dayLabel = document.createElement("div");
-      dayLabel.className = "calendar-day-label";
-      dayLabel.textContent = String(dayDate.getDate());
-      cell.appendChild(dayLabel);
+      if (dayDate.getTime() > maxVisible) {
+        cell.classList.add("calendar-day-future");
+      }
+
+      const label = document.createElement("div");
+      label.className = "calendar-day-label";
+      label.textContent = String(dayDate.getDate());
+      cell.appendChild(label);
 
       (byDay.get(key) || [])
         .sort((a, b) => (a.startAt || 0) - (b.startAt || 0))
         .forEach((event) => {
+          const status = resolveStatus(event, now);
           const row = document.createElement("div");
           row.className = "calendar-event";
 
-          const text = document.createElement("button");
-          text.className = "calendar-event-btn is-generated";
-          text.disabled = true;
-          text.textContent = `${formatTimeRange(event)} ${event.title} [${event.kind}]`;
-          row.appendChild(text);
+          const button = document.createElement("button");
+          button.className = `calendar-event-btn is-generated status-${status}`;
+          button.disabled = true;
+          button.appendChild(createStatusDot(status));
+
+          const text = document.createElement("span");
+          text.textContent = `${snapshotPrefix(status)} ${formatTimeRange(event)} ${event.title} [${event.kind}]`;
+          button.appendChild(text);
+
+          row.appendChild(button);
           cell.appendChild(row);
         });
 

--- a/src/modules/financeGuard.js
+++ b/src/modules/financeGuard.js
@@ -1,0 +1,68 @@
+const FINANCE_PASSWORD = "5621";
+
+export function initFinanceGuard(elements) {
+  let isFinanceUnlocked = false;
+
+  const modal = elements.financeGuardModal;
+  const input = elements.financePasswordInput;
+  const unlockBtn = elements.financeUnlockBtn;
+  const cancelBtn = elements.financeCancelBtn;
+
+  function closeModal() {
+    modal.hidden = true;
+    input.value = "";
+  }
+
+  function openModal() {
+    modal.hidden = false;
+    input.value = "";
+    input.focus();
+  }
+
+  function promptPassword() {
+    return new Promise((resolve) => {
+      const onUnlock = () => {
+        if (input.value === FINANCE_PASSWORD) {
+          isFinanceUnlocked = true;
+          cleanup();
+          closeModal();
+          resolve(true);
+          return;
+        }
+        alert("Wrong password");
+      };
+
+      const onCancel = () => {
+        cleanup();
+        closeModal();
+        resolve(false);
+      };
+
+      const onEnter = (event) => {
+        if (event.key === "Enter") onUnlock();
+      };
+
+      function cleanup() {
+        unlockBtn.removeEventListener("click", onUnlock);
+        cancelBtn.removeEventListener("click", onCancel);
+        input.removeEventListener("keydown", onEnter);
+      }
+
+      unlockBtn.addEventListener("click", onUnlock);
+      cancelBtn.addEventListener("click", onCancel);
+      input.addEventListener("keydown", onEnter);
+      openModal();
+    });
+  }
+
+  function lockFinance() {
+    isFinanceUnlocked = false;
+  }
+
+  async function canAccessFinance() {
+    if (isFinanceUnlocked) return true;
+    return promptPassword();
+  }
+
+  return { canAccessFinance, lockFinance };
+}

--- a/src/modules/focus.js
+++ b/src/modules/focus.js
@@ -1,150 +1,112 @@
 import {
-  startFocusSession,
-  finalizeFocusSession,
+  startSession,
+  cancelSession,
+  completeSession,
   subscribeFocusSessions,
   getFocusSessionState,
-  deleteFocusSession as removeFocusSession
 } from "../services/focusService.js";
 
-function buildActions(actions) {
-  const wrap = document.createElement("div");
-  wrap.className = "item-actions";
-  actions.forEach(({ label, onClick, className }) => {
-    const btn = document.createElement("button");
-    btn.textContent = label;
-    btn.className = className || "";
-    btn.addEventListener("click", onClick);
-    wrap.appendChild(btn);
-  });
-  return wrap;
-}
-
 export function initFocus(elements, notifyError) {
-  let focusInterval = null;
+  let timerId = null;
   let activeSessionId = null;
-  let activeSessionStart = null;
-  let activeSessionDuration = null;
+  let activeStart = null;
+  let activeDuration = null;
 
-  function updateTimerDisplay(seconds) {
-    const safe = Math.max(0, seconds);
+  function updateTimerView(seconds) {
+    const safe = Math.max(0, Number(seconds || 0));
     const mm = Math.floor(safe / 60);
     const ss = safe % 60;
-    elements.focusTimer.textContent = `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+    elements.focusDashboardTimer.textContent = `${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
   }
 
-  async function finalizeSession(status) {
+  function updateDashboardStats(sessions) {
+    const list = Object.values(sessions || {});
+    const today = new Date().toDateString();
+    const todayRows = list.filter(
+      (row) => row.createdAt && new Date(row.createdAt).toDateString() === today,
+    );
+    const completedToday = todayRows.filter((row) => row.status === "completed");
+    const totalMinutes = completedToday.reduce((sum, row) => sum + Number(row.duration || 0), 0);
+    elements.focusSessionToday.textContent = String(completedToday.length);
+    elements.focusTotalTimeToday.textContent = `${totalMinutes}m`;
+  }
+
+  async function finalizeActiveSession(status) {
     if (!activeSessionId) return;
-    await finalizeFocusSession(activeSessionId, status);
-    activeSessionId = null;
-    activeSessionStart = null;
-    activeSessionDuration = null;
+    if (timerId) {
+      clearInterval(timerId);
+      timerId = null;
+    }
+
+    try {
+      if (status === "completed") {
+        await completeSession(activeSessionId);
+      } else {
+        await cancelSession(activeSessionId);
+      }
+      activeSessionId = null;
+      activeStart = null;
+      activeDuration = null;
+      updateTimerView(0);
+    } catch (error) {
+      notifyError(error, "Failed to update focus session");
+    }
   }
 
-  function startFocusTimer(startTime, durationMinutes) {
-    if (focusInterval) clearInterval(focusInterval);
-    const totalSeconds = durationMinutes * 60;
+  function startTicker() {
+    if (!activeStart || !activeDuration) return;
+    if (timerId) clearInterval(timerId);
 
+    const total = activeDuration * 60;
     const tick = async () => {
-      const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
-      const remaining = totalSeconds - elapsedSeconds;
-      updateTimerDisplay(remaining);
-
+      const elapsed = Math.floor((Date.now() - activeStart) / 1000);
+      const remaining = total - elapsed;
+      updateTimerView(remaining);
       if (remaining <= 0) {
-        clearInterval(focusInterval);
-        focusInterval = null;
-        try {
-          await finalizeSession("completed");
-        } catch (error) {
-          notifyError(error, "Failed to finalize focus session");
-        }
+        await finalizeActiveSession("completed");
       }
     };
 
     tick();
-    focusInterval = setInterval(tick, 1000);
+    timerId = setInterval(tick, 1000);
   }
 
-  async function beginFocusSession(minutes) {
-    if (!minutes || minutes <= 0) return notifyError(new Error("Invalid focus duration"));
-    if (activeSessionId) return alert("A focus session is already active.");
+  async function handleStart() {
+    if (activeSessionId) return;
 
     try {
-      const session = await startFocusSession(minutes);
-      activeSessionId = session.sessionId;
-      activeSessionStart = session.startTime;
-      activeSessionDuration = session.duration;
-
-      startFocusTimer(activeSessionStart, activeSessionDuration);
+      const state = await startSession(90);
+      activeSessionId = state.sessionId;
+      activeStart = state.startTime;
+      activeDuration = state.duration;
+      startTicker();
     } catch (error) {
       notifyError(error, "Failed to start focus session");
     }
   }
 
-  async function cancelActiveFocusSession() {
-    if (!activeSessionId) return;
-    if (focusInterval) {
-      clearInterval(focusInterval);
-      focusInterval = null;
-    }
-    try {
-      await finalizeSession("cancelled");
-      updateTimerDisplay(0);
-    } catch (error) {
-      notifyError(error, "Failed to cancel focus session");
-    }
-  }
-
-  async function deleteFocusSession(sessionId) {
-    try {
-      if (sessionId === activeSessionId) {
-        await cancelActiveFocusSession();
-      }
-      await removeFocusSession(sessionId);
-    } catch (error) {
-      notifyError(error, "Failed to delete focus session");
-    }
-  }
-
-  async function restoreFocusSessionIfAny() {
+  async function restoreIfNeeded() {
     try {
       const state = await getFocusSessionState();
-      if (!state || !state.focusSessionActive) return;
+      if (!state?.focusSessionActive) return;
       activeSessionId = state.sessionId;
-      activeSessionStart = state.startTime;
-      activeSessionDuration = state.duration;
-      startFocusTimer(activeSessionStart, activeSessionDuration);
+      activeStart = state.startTime;
+      activeDuration = state.duration;
+      startTicker();
     } catch (error) {
       notifyError(error, "Failed to restore focus session");
     }
   }
 
-  elements.cancelFocusBtn.addEventListener("click", cancelActiveFocusSession);
-  elements.focusButtons.forEach((button) => {
-    button.addEventListener("click", () => beginFocusSession(Number(button.dataset.duration)));
-  });
+  elements.focusDashboardStartBtn?.addEventListener("click", handleStart);
+  elements.focusDashboardStopBtn?.addEventListener("click", () =>
+    finalizeActiveSession("cancelled"),
+  );
 
   const unsubscribe = subscribeFocusSessions((sessions) => {
-    elements.focusSessionList.innerHTML = "";
-    if (!sessions) return;
-
-    Object.entries(sessions)
-      .sort(([, a], [, b]) => (b.createdAt || 0) - (a.createdAt || 0))
-      .forEach(([id, session]) => {
-        const li = document.createElement("li");
-        const text = document.createElement("span");
-        text.textContent = `${session.duration}m — ${session.status || "unknown"}`;
-        li.appendChild(text);
-
-        const actions = [];
-        if (id === activeSessionId && session.status === "active") {
-          actions.push({ label: "Cancel", onClick: cancelActiveFocusSession });
-        }
-        actions.push({ label: "Delete", className: "btn-danger", onClick: () => deleteFocusSession(id) });
-        li.appendChild(buildActions(actions));
-        elements.focusSessionList.appendChild(li);
-      });
+    updateDashboardStats(sessions);
   });
 
-  restoreFocusSessionIfAny();
+  restoreIfNeeded();
   return unsubscribe;
 }

--- a/src/modules/webShortcuts.js
+++ b/src/modules/webShortcuts.js
@@ -1,0 +1,36 @@
+import { getShortcuts } from "../services/webShortcutService.js";
+
+const FALLBACK_SHORTCUTS = [
+  { name: "YouTube", url: "https://youtube.com", icon: "youtube", order: 1 },
+  { name: "ChatGPT", url: "https://chatgpt.com", icon: "chatgpt", order: 2 },
+  { name: "Gmail", url: "https://mail.google.com", icon: "gmail", order: 3 },
+  { name: "Github", url: "https://github.com", icon: "github", order: 4 },
+];
+
+function asList(shortcuts) {
+  if (!shortcuts || !Object.keys(shortcuts).length) return FALLBACK_SHORTCUTS;
+  return Object.values(shortcuts)
+    .filter((item) => item?.name && item?.url)
+    .sort((a, b) => Number(a.order || 0) - Number(b.order || 0));
+}
+
+export function initWebShortcuts(elements) {
+  const container = elements.webShortcutsContainer;
+  if (!container) return () => {};
+
+  function render(shortcuts) {
+    container.innerHTML = "";
+    asList(shortcuts).forEach((item) => {
+      const button = document.createElement("button");
+      button.className = "shortcut-btn";
+      button.type = "button";
+      button.textContent = item.name;
+      button.addEventListener("click", () => {
+        window.open(item.url, "_blank");
+      });
+      container.appendChild(button);
+    });
+  }
+
+  return getShortcuts(render);
+}

--- a/src/services/focusService.js
+++ b/src/services/focusService.js
@@ -8,7 +8,7 @@ export async function startFocusSession(minutes) {
     duration: minutes,
     status: "active",
     endedAt: null,
-    createdAt: now
+    createdAt: now,
   });
 
   const sessionId = sessionRef.key;
@@ -16,7 +16,7 @@ export async function startFocusSession(minutes) {
     focusSessionActive: true,
     sessionId,
     startTime: now,
-    duration: minutes
+    duration: minutes,
   });
 
   return { sessionId, startTime: now, duration: minutes };
@@ -40,4 +40,16 @@ export function getFocusSessionState() {
 
 export function deleteFocusSession(sessionId) {
   return focusApi.deleteSessionById(sessionId);
+}
+
+export async function startSession(minutes = 90) {
+  return startFocusSession(minutes);
+}
+
+export async function cancelSession(sessionId) {
+  return finalizeFocusSession(sessionId, "cancelled");
+}
+
+export async function completeSession(sessionId) {
+  return finalizeFocusSession(sessionId, "completed");
 }

--- a/src/services/webShortcutService.js
+++ b/src/services/webShortcutService.js
@@ -1,0 +1,28 @@
+import { webShortcutsApi } from "../core/firebaseService.js";
+
+export function getShortcuts(callback) {
+  return webShortcutsApi.subscribe(callback);
+}
+
+export async function createShortcut(payload) {
+  const now = Date.now();
+  return webShortcutsApi.add({
+    name: String(payload?.name || "").trim(),
+    url: String(payload?.url || "").trim(),
+    icon: String(payload?.icon || "link").trim(),
+    order: Number(payload?.order || now),
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+export async function deleteShortcut(shortcutId) {
+  return webShortcutsApi.deleteById(shortcutId);
+}
+
+export async function updateShortcut(shortcutId, payload = {}) {
+  return webShortcutsApi.updateById(shortcutId, {
+    ...payload,
+    updatedAt: Date.now(),
+  });
+}

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -8,6 +8,8 @@ import { initCalendar } from "../modules/calendar.js";
 import { initFocus } from "../modules/focus.js";
 import { initNotes } from "../modules/notes.js";
 import { initSettings } from "../modules/settings.js";
+import { initWebShortcuts } from "../modules/webShortcuts.js";
+import { initFinanceGuard } from "../modules/financeGuard.js";
 import { createNote } from "../services/noteService.js";
 
 const elements = {
@@ -70,10 +72,11 @@ const elements = {
   kanbanTodo: document.getElementById("kanban-todo"),
   kanbanInProgress: document.getElementById("kanban-in-progress"),
   kanbanDone: document.getElementById("kanban-done"),
-  focusTimer: document.getElementById("focusTimer"),
-  focusButtons: document.querySelectorAll(".focus-controls button[data-duration]"),
-  cancelFocusBtn: document.getElementById("cancelFocusBtn"),
-  focusSessionList: document.getElementById("focusSessionList"),
+  focusDashboardTimer: document.getElementById("focusDashboardTimer"),
+  focusDashboardStartBtn: document.getElementById("focusDashboardStartBtn"),
+  focusDashboardStopBtn: document.getElementById("focusDashboardStopBtn"),
+  focusSessionToday: document.getElementById("focusSessionToday"),
+  focusTotalTimeToday: document.getElementById("focusTotalTimeToday"),
   noteInput: document.getElementById("noteInput"),
   saveNoteBtn: document.getElementById("saveNoteBtn"),
   notesList: document.getElementById("notesList"),
@@ -95,6 +98,11 @@ const elements = {
   calendarMonthLabel: document.getElementById("calendarMonthLabel"),
   calendarWeekdays: document.getElementById("calendarWeekdays"),
   calendarGrid: document.getElementById("calendarGrid"),
+  webShortcutsContainer: document.getElementById("webShortcutsContainer"),
+  financeGuardModal: document.getElementById("financeGuardModal"),
+  financePasswordInput: document.getElementById("financePasswordInput"),
+  financeUnlockBtn: document.getElementById("financeUnlockBtn"),
+  financeCancelBtn: document.getElementById("financeCancelBtn"),
 };
 
 function notifyError(error, fallback = "Operation failed") {
@@ -121,11 +129,27 @@ function switchCalendarMode(mode) {
   });
 }
 
-function initNavigation() {
-  elements.sidebarNav.addEventListener("click", (event) => {
+function initNavigation(financeGuard) {
+  elements.sidebarNav.addEventListener("click", async (event) => {
     const button = event.target.closest(".nav-btn");
     if (!button) return;
-    switchMainView(button.dataset.view);
+
+    const targetView = button.dataset.view;
+    const currentView = document.querySelector(".main-view.is-active")?.dataset.view;
+
+    if (currentView === "finance" && targetView !== "finance") {
+      financeGuard.lockFinance();
+    }
+
+    if (targetView === "finance") {
+      const allowed = await financeGuard.canAccessFinance();
+      if (!allowed) {
+        switchMainView(currentView || "dashboard");
+        return;
+      }
+    }
+
+    switchMainView(targetView);
   });
 
   elements.toggleTaskCreationBtn.addEventListener("click", () => {
@@ -236,7 +260,6 @@ function observeDashboardData() {
     elements.dailyTaskList,
     elements.taskList,
     elements.habitList,
-    elements.focusSessionList,
     elements.calendarGrid,
     elements.level,
     elements.exp,
@@ -267,12 +290,12 @@ function initActivityLog() {
       li.textContent = entry.message || `+${entry.value} ${String(entry.stat || "").toUpperCase()}`;
       elements.activityLogList.appendChild(li);
     });
-
   });
 }
 
 function init() {
-  initNavigation();
+  const financeGuard = initFinanceGuard(elements);
+  initNavigation(financeGuard);
   initRewardEngine({ notifyError });
   initStats(elements);
   initTasks(elements, notifyError);
@@ -282,6 +305,7 @@ function init() {
   initFinance(elements, notifyError);
   initFocus(elements, notifyError);
   initCalendar(elements, notifyError);
+  initWebShortcuts(elements);
   initQuickNote();
   initDateTime();
   initActivityLog();

--- a/style.css
+++ b/style.css
@@ -343,3 +343,55 @@ button {
 .settings-reset-actions {
   flex-wrap: wrap;
 }
+
+.dashboard-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.shortcut-btn {
+  width: auto;
+  min-width: 110px;
+}
+.focus-controls-dashboard {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.focus-dashboard-stats {
+  display: grid;
+  gap: 6px;
+  margin-top: 8px;
+  color: #c6d6ef;
+}
+.calendar-day-future {
+  opacity: 0.3;
+}
+.calendar-event-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.calendar-status-dot.is-completed {
+  color: #4caf50;
+}
+.calendar-status-dot.is-pending {
+  color: #ffc107;
+}
+.calendar-status-dot.is-fail {
+  color: #f44336;
+}
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+.modal-card {
+  width: min(360px, 92vw);
+  background: #171c26;
+  border: 1px solid #2a3242;
+  border-radius: 12px;
+  padding: 14px;
+}


### PR DESCRIPTION
### Motivation
- Provide quick-access web shortcuts from the dashboard, move Focus Session onto the dashboard, and add a client-side finance lock per the feature spec.
- Improve calendar UX by auto-determining task status and dimming tasks outside a 4-day visibility window.
- Expose a small Firebase surface for storing shortcuts so shortcuts can be managed remotely.

### Description
- Added a Firebase `webShortcuts` path and API: updated `src/core/schema.js` and `src/core/firebaseService.js`, and re-exported `webShortcutsApi` from `src/core/firebase.js`.
- New service and module for shortcuts: `src/services/webShortcutService.js` subscribes to shortcuts and CRUDs them, and `src/modules/webShortcuts.js` renders ordered buttons that call `window.open(url, "_blank")` with fallback defaults.
- Moved focus session into the dashboard: removed the standalone Focus sidebar button and added dashboard controls and stats in `index.html`, wired by `src/modules/focus.js` (uses `startSession`, `cancelSession`, `completeSession` aliases in `src/services/focusService.js`).
- Added client-side finance guard: `src/modules/financeGuard.js` implements a modal password prompt (password `5621`), `initFinanceGuard` is integrated into navigation in `src/ui/ui.js` so Finance requires unlock and is re-locked when leaving.
- Enhanced calendar rendering in `src/modules/calendar.js` to compute `completed`/`pending`/`fail` status based on time and completion, add a 4-day visibility window (future dimming), render colored status dots and snapshot-style labels for export/preview.
- Updated UI bootstrap: `src/ui/ui.js` registers `initWebShortcuts` and `initFinanceGuard`, wires new dashboard elements, and adjusts observers; added styles in `style.css` for shortcuts, focus dashboard, calendar status dots and the modal.

### Testing
- Ran lint: `npm run lint` completed with no errors.
- Ran unit tests: `npm test` executed `tests/*.test.js` and all tests passed (5/5).
- Manual UI verification: served the app with `python -m http.server 4173` and captured a Playwright screenshot of the dashboard to validate layout and interactions (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b382be0a78832385481c36cc891ef9)