### PR TITLE
Add Word Cloud voting tab with Firebase one-vote enforcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
           <button class="nav-btn" data-view="settings" title="Settings">⚙️</button>
           <button class="nav-btn" data-view="finance" title="Finance">💰</button>
           <button class="nav-btn" data-view="stats" title="Stats">📊</button>
+          <button class="nav-btn" data-view="word-cloud" title="Word Cloud">☁️</button>
         </nav>
       </aside>
 
@@ -181,6 +182,27 @@
               <button id="addTransactionBtn">Add</button>
             </div>
             <ul id="transactionList"></ul>
+          </section>
+        </section>
+
+
+        <section class="main-view" data-view="word-cloud">
+          <section class="card word-cloud">
+            <h2>Word Cloud Voting</h2>
+            <div class="word-cloud-controls">
+              <label>Thời gian (phút)</label>
+              <input type="number" id="wordCloudDurationInput" min="1" value="3" />
+              <button id="wordCloudStartBtn">Bắt đầu bình chọn</button>
+              <strong id="wordCloudStatus">Đã đóng</strong>
+            </div>
+            <div class="word-cloud-controls">
+              <input type="text" id="wordCloudVoterIdInput" placeholder="Mã người dùng" />
+              <input type="text" id="wordCloudVoteInput" maxlength="3" placeholder="Nhập tối đa 3 ký tự" />
+              <button id="wordCloudVoteBtn">Vote</button>
+            </div>
+            <div id="wordCloudCloud" class="word-cloud-canvas"></div>
+            <h3>Top bình chọn</h3>
+            <ol id="wordCloudTopList"></ol>
           </section>
         </section>
 

--- a/src/core/firebase.js
+++ b/src/core/firebase.js
@@ -12,6 +12,7 @@ export {
   activityApi,
   calendarApi,
   webShortcutsApi,
+  wordCloudApi,
   resetTasksDomain,
   resetEntireDatabase,
 } from "./firebaseService.js";

--- a/src/core/firebaseService.js
+++ b/src/core/firebaseService.js
@@ -198,6 +198,21 @@ export const calendarApi = {
   deleteEventById: (eventId) => destroy(`${PATHS.calendarEvents}/${eventId}`),
 };
 
+
+export const wordCloudApi = {
+  subscribePollState: (callback) => subscribe(PATHS.wordCloudPollState, callback),
+  setPollState: (state) => write(PATHS.wordCloudPollState, state),
+  subscribeVotes: (callback) => subscribe(PATHS.wordCloudVotes, callback),
+  voteOnce: async (voterId, value) => {
+    const txPath = `${PATHS.wordCloudVotes}/${voterId}`;
+    const result = await transaction(txPath, (current) => {
+      if (current) return current;
+      return { voterId, value, createdAt: Date.now() };
+    });
+    return Boolean(result && result.value === value);
+  },
+};
+
 export async function resetTasksDomain() {
   await Promise.all([
     write(PATHS.tasks, null),

--- a/src/core/schema.js
+++ b/src/core/schema.js
@@ -12,4 +12,6 @@ export const PATHS = Object.freeze({
   calendar: "calendar",
   calendarEvents: "calendar/events",
   webShortcuts: "webShortcuts",
+  wordCloudPollState: "wordCloud/pollState",
+  wordCloudVotes: "wordCloud/votes",
 });

--- a/src/modules/wordCloud.js
+++ b/src/modules/wordCloud.js
@@ -1,0 +1,133 @@
+import { wordCloudApi } from "../core/firebase.js";
+
+function normalizeVoterId(value) {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, "-");
+}
+
+function isPollOpen(pollState) {
+  return Boolean(pollState?.isOpen) && Number(pollState?.endsAt || 0) > Date.now();
+}
+
+function computeTopThree(votesMap) {
+  const counter = new Map();
+  Object.values(votesMap || {}).forEach((entry) => {
+    if (!entry?.value) return;
+    counter.set(entry.value, (counter.get(entry.value) || 0) + 1);
+  });
+
+  return [...counter.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 3)
+    .map(([value, count], index) => ({ rank: index + 1, value, count }));
+}
+
+function renderWordCloud(container, votesMap) {
+  const counter = new Map();
+  Object.values(votesMap || {}).forEach((entry) => {
+    if (!entry?.value) return;
+    counter.set(entry.value, (counter.get(entry.value) || 0) + 1);
+  });
+
+  container.innerHTML = "";
+  if (!counter.size) {
+    container.textContent = "Chưa có vote nào.";
+    return;
+  }
+
+  const max = Math.max(...counter.values());
+  [...counter.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .forEach(([value, count]) => {
+      const chip = document.createElement("span");
+      chip.className = "word-cloud-item";
+      const scale = 0.7 + (count / max) * 1.3;
+      chip.style.fontSize = `${Math.round(scale * 16)}px`;
+      chip.textContent = `${value} (${count})`;
+      container.appendChild(chip);
+    });
+}
+
+export function initWordCloud(elements, notifyError) {
+  const state = { pollState: null, votes: {} };
+
+  const render = () => {
+    const open = isPollOpen(state.pollState);
+    const endsAt = Number(state.pollState?.endsAt || 0);
+    elements.wordCloudStatus.textContent = open
+      ? `Đang mở đến ${new Date(endsAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+      : "Đã đóng";
+
+    elements.wordCloudVoteBtn.disabled = !open;
+
+    renderWordCloud(elements.wordCloudCloud, state.votes);
+
+    const topThree = computeTopThree(state.votes);
+    elements.wordCloudTopList.innerHTML = "";
+    if (!topThree.length) {
+      const li = document.createElement("li");
+      li.textContent = "Chưa đủ dữ liệu";
+      elements.wordCloudTopList.appendChild(li);
+    } else {
+      topThree.forEach((item) => {
+        const li = document.createElement("li");
+        li.textContent = `#${item.rank}: ${item.value} (${item.count} votes)`;
+        elements.wordCloudTopList.appendChild(li);
+      });
+    }
+  };
+
+  wordCloudApi.subscribePollState((pollState) => {
+    state.pollState = pollState;
+    render();
+  });
+
+  wordCloudApi.subscribeVotes((votes) => {
+    state.votes = votes || {};
+    render();
+  });
+
+  elements.wordCloudStartBtn.addEventListener("click", async () => {
+    try {
+      const minutes = Number(elements.wordCloudDurationInput.value || 3);
+      const durationMs = Math.max(1, minutes) * 60 * 1000;
+      const now = Date.now();
+      await wordCloudApi.setPollState({
+        isOpen: true,
+        startedAt: now,
+        endsAt: now + durationMs,
+      });
+    } catch (error) {
+      notifyError(error, "Không thể bắt đầu bình chọn");
+    }
+  });
+
+  elements.wordCloudVoteBtn.addEventListener("click", async () => {
+    try {
+      const voterId = normalizeVoterId(elements.wordCloudVoterIdInput.value);
+      const value = String(elements.wordCloudVoteInput.value || "").trim();
+      if (!voterId) throw new Error("Nhập mã người dùng");
+      if (!value) throw new Error("Nhập nội dung bình chọn");
+      if (value.length > 3) throw new Error("Tối đa 3 ký tự");
+      if (!isPollOpen(state.pollState)) throw new Error("Phiên bình chọn đã đóng");
+
+      const result = await wordCloudApi.voteOnce(voterId, value);
+      if (!result) throw new Error("Bạn đã vote trước đó");
+      elements.wordCloudVoteInput.value = "";
+    } catch (error) {
+      notifyError(error, "Vote thất bại");
+    }
+  });
+
+  setInterval(() => {
+    if (isPollOpen(state.pollState)) {
+      render();
+      return;
+    }
+    if (state.pollState?.isOpen) {
+      wordCloudApi.setPollState({ ...state.pollState, isOpen: false });
+    }
+    render();
+  }, 1000);
+
+  render();
+}

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -9,6 +9,7 @@ import { initNotes } from "../modules/notes.js";
 import { initSettings } from "../modules/settings.js";
 import { initWebShortcuts } from "../modules/webShortcuts.js";
 import { initFinanceGuard } from "../modules/financeGuard.js";
+import { initWordCloud } from "../modules/wordCloud.js";
 import { createNote } from "../services/noteService.js";
 import { buildScheduledItems, toDayKey } from "../core/calendarLogic.js";
 import { isWeeklyHabitDueOnDate } from "../core/habitLogic.js";
@@ -101,6 +102,14 @@ const elements = {
   financePasswordInput: document.getElementById("financePasswordInput"),
   financeUnlockBtn: document.getElementById("financeUnlockBtn"),
   financeCancelBtn: document.getElementById("financeCancelBtn"),
+  wordCloudDurationInput: document.getElementById("wordCloudDurationInput"),
+  wordCloudStartBtn: document.getElementById("wordCloudStartBtn"),
+  wordCloudStatus: document.getElementById("wordCloudStatus"),
+  wordCloudVoterIdInput: document.getElementById("wordCloudVoterIdInput"),
+  wordCloudVoteInput: document.getElementById("wordCloudVoteInput"),
+  wordCloudVoteBtn: document.getElementById("wordCloudVoteBtn"),
+  wordCloudCloud: document.getElementById("wordCloudCloud"),
+  wordCloudTopList: document.getElementById("wordCloudTopList"),
 };
 
 function notifyError(error, fallback = "Operation failed") {
@@ -317,6 +326,7 @@ function init() {
   initFocus(elements, notifyError);
   initCalendar(elements, notifyError);
   initWebShortcuts(elements);
+  initWordCloud(elements, notifyError);
   initQuickNote();
   initDateTime();
   initActivityLog();

--- a/style.css
+++ b/style.css
@@ -525,3 +525,31 @@ h4 {
   background: rgba(96, 165, 250, 0.24);
   border-color: rgba(96, 165, 250, 0.75);
 }
+
+
+.word-cloud {
+  display: grid;
+  gap: 12px;
+}
+.word-cloud-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.word-cloud-canvas {
+  min-height: 180px;
+  border: 1px dashed var(--border-light);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+.word-cloud-item {
+  background: rgba(92, 161, 255, 0.15);
+  border: 1px solid rgba(92, 161, 255, 0.3);
+  border-radius: 999px;
+  padding: 4px 10px;
+}


### PR DESCRIPTION
### Motivation
- Provide an in-app, easy-to-use “Word Cloud” voting experience that stores data in Firebase and produces a ranked top-3 report. 
- Enforce a single vote per participant and a short (configurable) voting window (default 3 minutes) to support quick polls during sessions.

### Description
- Added a new sidebar button and main view for the Word Cloud in `index.html` and integrated controls for duration, voter id, vote input and a top-3 report. 
- Implemented voting UI and client logic in `src/modules/wordCloud.js` including input validation (max 3 characters), poll lifecycle, live cloud rendering and top-3 computation. 
- Extended Firebase schema and service APIs by adding `wordCloudPollState` and `wordCloudVotes` paths in `src/core/schema.js` and a `wordCloudApi` (including transactional `voteOnce`) in `src/core/firebaseService.js`, and exported it from `src/core/firebase.js`. 
- Wired the module into app bootstrap (`src/ui/ui.js`) and added styling in `style.css` for a clean, responsive interface. 

### Testing
- Ran `npm test` which passed all unit tests (21 tests passed). 
- Ran `npm run lint` which failed due to unrelated, pre-existing unused-variable lint errors in `src/services/taskService.js` and therefore did not pass lint checks for the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141ee012b4832390a5c671c4ddf519)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Word Cloud voting feature with customizable duration controls and real-time poll visualization.
  * Users can input voter IDs and cast votes displayed as scaled word cloud elements.
  * Live ranking displays top votes with automatic poll closure upon expiration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Minhmovtpt/I-can-do/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->