### PR TITLE
Add role-gated Word Cloud voting flow with admin controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,18 +12,18 @@
       <aside class="sidebar card">
         <h2>Mode</h2>
         <nav class="sidebar-nav" id="sidebarNav">
-          <button class="nav-btn is-active" data-view="dashboard" title="Dashboard">🏠</button>
-          <button class="nav-btn" data-view="calendar" title="Calendar">📅</button>
-          <button class="nav-btn" data-view="notes" title="Notes">📝</button>
-          <button class="nav-btn" data-view="settings" title="Settings">⚙️</button>
-          <button class="nav-btn" data-view="finance" title="Finance">💰</button>
-          <button class="nav-btn" data-view="stats" title="Stats">📊</button>
-          <button class="nav-btn" data-view="word-cloud" title="Word Cloud">☁️</button>
+          <button class="nav-btn" data-view="dashboard" title="Dashboard" hidden>🏠</button>
+          <button class="nav-btn" data-view="calendar" title="Calendar" hidden>📅</button>
+          <button class="nav-btn" data-view="notes" title="Notes" hidden>📝</button>
+          <button class="nav-btn" data-view="settings" title="Settings" hidden>⚙️</button>
+          <button class="nav-btn" data-view="finance" title="Finance" hidden>💰</button>
+          <button class="nav-btn" data-view="stats" title="Stats" hidden>📊</button>
+          <button class="nav-btn is-active" data-view="word-cloud" title="Word Cloud">☁️</button>
         </nav>
       </aside>
 
       <main class="main-area">
-        <section class="main-view is-active" data-view="dashboard">
+        <section class="main-view" data-view="dashboard">
           <section class="card dashboard-card dashboard-compact" id="dateTimeCard">
             <h2>Date & Time</h2>
             <div class="date-time-day" id="currentDayOfWeek">-</div>
@@ -186,13 +186,14 @@
         </section>
 
 
-        <section class="main-view" data-view="word-cloud">
+        <section class="main-view is-active" data-view="word-cloud">
           <section class="card word-cloud">
             <h2>Word Cloud Voting</h2>
             <div class="word-cloud-controls">
               <label>Thời gian (phút)</label>
               <input type="number" id="wordCloudDurationInput" min="1" value="3" />
-              <button id="wordCloudStartBtn">Bắt đầu bình chọn</button>
+              <button id="wordCloudStartBtn">Bắt đầu/Cập nhật</button>
+              <button id="wordCloudStopBtn" class="btn-danger">Dừng</button>
               <strong id="wordCloudStatus">Đã đóng</strong>
             </div>
             <div class="word-cloud-controls">
@@ -323,5 +324,20 @@
     </div>
 
     <script type="module" src="./src/ui/ui.js"></script>
+    <div class="role-popup" id="wordCloudRolePopup">
+      <div class="role-popup-card card">
+        <h2>Chọn vai trò</h2>
+        <p>Vui lòng chọn vai trò để vào phiên Word Cloud.</p>
+        <div class="item-actions">
+          <button id="wordCloudSelectAdminBtn">Admin</button>
+          <button id="wordCloudSelectVoterBtn">Voter</button>
+        </div>
+        <div id="wordCloudVoterDeclareArea" hidden>
+          <input type="text" id="wordCloudDeclareVoterIdInput" placeholder="Nhập số/mã của bạn" />
+          <button id="wordCloudConfirmVoterBtn">Xác nhận vào voter</button>
+        </div>
+      </div>
+    </div>
+
   </body>
 </html>

--- a/src/modules/wordCloud.js
+++ b/src/modules/wordCloud.js
@@ -48,7 +48,25 @@ function renderWordCloud(container, votesMap) {
 }
 
 export function initWordCloud(elements, notifyError) {
-  const state = { pollState: null, votes: {} };
+  const state = { pollState: null, votes: {}, role: null, declaredVoterId: "" };
+
+  const applyRoleUi = () => {
+    const isAdmin = state.role === "admin";
+    const isVoter = state.role === "voter";
+
+    elements.wordCloudDurationInput.disabled = !isAdmin;
+    elements.wordCloudStartBtn.hidden = !isAdmin;
+    elements.wordCloudStopBtn.hidden = !isAdmin;
+
+    elements.wordCloudVoterIdInput.disabled = !isVoter;
+    elements.wordCloudVoteInput.disabled = !isVoter;
+    elements.wordCloudVoteBtn.hidden = !isVoter;
+
+    if (isVoter) {
+      elements.wordCloudVoterIdInput.value = state.declaredVoterId;
+      elements.wordCloudVoterIdInput.readOnly = true;
+    }
+  };
 
   const render = () => {
     const open = isPollOpen(state.pollState);
@@ -86,6 +104,28 @@ export function initWordCloud(elements, notifyError) {
     render();
   });
 
+  elements.wordCloudSelectAdminBtn.addEventListener("click", () => {
+    state.role = "admin";
+    elements.wordCloudRolePopup.hidden = true;
+    applyRoleUi();
+  });
+
+  elements.wordCloudSelectVoterBtn.addEventListener("click", () => {
+    elements.wordCloudVoterDeclareArea.hidden = false;
+  });
+
+  elements.wordCloudConfirmVoterBtn.addEventListener("click", () => {
+    const declaredId = normalizeVoterId(elements.wordCloudDeclareVoterIdInput.value);
+    if (!declaredId) {
+      notifyError(new Error("Vui lòng nhập số/mã voter"), "Thiếu mã voter");
+      return;
+    }
+    state.role = "voter";
+    state.declaredVoterId = declaredId;
+    elements.wordCloudRolePopup.hidden = true;
+    applyRoleUi();
+  });
+
   elements.wordCloudStartBtn.addEventListener("click", async () => {
     try {
       const minutes = Number(elements.wordCloudDurationInput.value || 3);
@@ -101,11 +141,24 @@ export function initWordCloud(elements, notifyError) {
     }
   });
 
+  elements.wordCloudStopBtn.addEventListener("click", async () => {
+    try {
+      await wordCloudApi.setPollState({
+        ...(state.pollState || {}),
+        isOpen: false,
+        endsAt: Date.now(),
+      });
+    } catch (error) {
+      notifyError(error, "Không thể dừng bình chọn");
+    }
+  });
+
   elements.wordCloudVoteBtn.addEventListener("click", async () => {
     try {
       const voterId = normalizeVoterId(elements.wordCloudVoterIdInput.value);
       const value = String(elements.wordCloudVoteInput.value || "").trim();
       if (!voterId) throw new Error("Nhập mã người dùng");
+      if (voterId !== state.declaredVoterId) throw new Error("Mã voter không khớp mã đã khai báo");
       if (!value) throw new Error("Nhập nội dung bình chọn");
       if (value.length > 3) throw new Error("Tối đa 3 ký tự");
       if (!isPollOpen(state.pollState)) throw new Error("Phiên bình chọn đã đóng");
@@ -129,5 +182,6 @@ export function initWordCloud(elements, notifyError) {
     render();
   }, 1000);
 
+  applyRoleUi();
   render();
 }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -104,12 +104,19 @@ const elements = {
   financeCancelBtn: document.getElementById("financeCancelBtn"),
   wordCloudDurationInput: document.getElementById("wordCloudDurationInput"),
   wordCloudStartBtn: document.getElementById("wordCloudStartBtn"),
+  wordCloudStopBtn: document.getElementById("wordCloudStopBtn"),
   wordCloudStatus: document.getElementById("wordCloudStatus"),
   wordCloudVoterIdInput: document.getElementById("wordCloudVoterIdInput"),
   wordCloudVoteInput: document.getElementById("wordCloudVoteInput"),
   wordCloudVoteBtn: document.getElementById("wordCloudVoteBtn"),
   wordCloudCloud: document.getElementById("wordCloudCloud"),
   wordCloudTopList: document.getElementById("wordCloudTopList"),
+  wordCloudSelectAdminBtn: document.getElementById("wordCloudSelectAdminBtn"),
+  wordCloudSelectVoterBtn: document.getElementById("wordCloudSelectVoterBtn"),
+  wordCloudRolePopup: document.getElementById("wordCloudRolePopup"),
+  wordCloudVoterDeclareArea: document.getElementById("wordCloudVoterDeclareArea"),
+  wordCloudDeclareVoterIdInput: document.getElementById("wordCloudDeclareVoterIdInput"),
+  wordCloudConfirmVoterBtn: document.getElementById("wordCloudConfirmVoterBtn"),
 };
 
 function notifyError(error, fallback = "Operation failed") {
@@ -317,6 +324,7 @@ function initActivityLog() {
 function init() {
   const financeGuard = initFinanceGuard(elements);
   initNavigation(financeGuard);
+  switchMainView("word-cloud");
   initRewardEngine({ notifyError });
   initStats(elements);
   initTasks(elements, notifyError);

--- a/style.css
+++ b/style.css
@@ -553,3 +553,26 @@ h4 {
   border-radius: 999px;
   padding: 4px 10px;
 }
+
+.role-popup {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+
+.role-popup[hidden] {
+  display: none;
+}
+
+.role-popup-card {
+  width: min(420px, 92vw);
+}
+
+#wordCloudVoterDeclareArea {
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+}


### PR DESCRIPTION
### Motivation
- Surface the Word Cloud voting experience as the default session and temporarily hide other navigation to focus users on voting. 
- Require a role selection so Admins can control the poll while Voters have a restricted entry flow. 
- Enforce that each voter declares an ID on entry and can only vote once using that declared ID.

### Description
- Update `index.html` to hide sidebar tabs except `word-cloud`, make the Word Cloud view active by default, add a role selection popup, and add a `Dừng` (stop) button for admins. 
- Add role and voter-declaration state and UI wiring in `src/ui/ui.js` and force the initial view to `word-cloud` via `switchMainView("word-cloud")`. 
- Replace the previous `wordCloud` module with a new `src/modules/wordCloud.js` that implements role handling (admin vs voter), requires voter ID declaration before voting, locks the voter ID, exposes `Start/Cập nhật` and `Dừng` actions for admins, and continues to use `wordCloudApi.voteOnce(...)` to keep one-vote-per-user behavior. 
- Add popup styling and related layout rules in `style.css` for the role selection overlay and voter-declare area.

### Testing
- Ran the automated test suite with `npm test -- --runInBand`. 
- All tests passed: `21/21` successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1422891bd083238acfc3b27138a363)