### PR TITLE
Restrict word cloud admin access and enhance vote visuals

### DIFF
--- a/src/modules/wordCloud.js
+++ b/src/modules/wordCloud.js
@@ -21,6 +21,20 @@ function computeTopThree(votesMap) {
     .map(([value, count], index) => ({ rank: index + 1, value, count }));
 }
 
+function colorFromValue(value, intensity) {
+  const text = String(value || "");
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) hash = (hash * 31 + text.charCodeAt(i)) % 360;
+
+  const lightness = Math.round(75 - intensity * 35);
+  const borderLightness = Math.max(20, lightness - 12);
+  return {
+    background: `hsl(${hash} 78% ${lightness}% / 0.35)`,
+    border: `hsl(${hash} 75% ${borderLightness}% / 0.8)`,
+    text: `hsl(${hash} 80% ${Math.max(12, borderLightness - 15)}%)`,
+  };
+}
+
 function renderWordCloud(container, votesMap) {
   const counter = new Map();
   Object.values(votesMap || {}).forEach((entry) => {
@@ -40,8 +54,14 @@ function renderWordCloud(container, votesMap) {
     .forEach(([value, count]) => {
       const chip = document.createElement("span");
       chip.className = "word-cloud-item";
-      const scale = 0.7 + (count / max) * 1.3;
+      const intensity = max ? count / max : 0;
+      const scale = 0.85 + intensity * 1.75;
+      const colors = colorFromValue(value, intensity);
       chip.style.fontSize = `${Math.round(scale * 16)}px`;
+      chip.style.transform = `scale(${(0.9 + intensity * 0.35).toFixed(2)})`;
+      chip.style.background = colors.background;
+      chip.style.borderColor = colors.border;
+      chip.style.color = colors.text;
       chip.textContent = `${value} (${count})`;
       container.appendChild(chip);
     });
@@ -105,6 +125,11 @@ export function initWordCloud(elements, notifyError) {
   });
 
   elements.wordCloudSelectAdminBtn.addEventListener("click", () => {
+    const adminCode = normalizeVoterId(window.prompt("Nhập mã admin") || "");
+    if (adminCode !== "9119") {
+      notifyError(new Error("Chỉ mã 9119 mới được làm admin"), "Sai mã admin");
+      return;
+    }
     state.role = "admin";
     elements.wordCloudRolePopup.hidden = true;
     applyRoleUi();

--- a/src/modules/wordCloud.js
+++ b/src/modules/wordCloud.js
@@ -127,7 +127,7 @@ export function initWordCloud(elements, notifyError) {
   elements.wordCloudSelectAdminBtn.addEventListener("click", () => {
     const adminCode = normalizeVoterId(window.prompt("Nhập mã admin") || "");
     if (adminCode !== "9119") {
-      notifyError(new Error("Chỉ mã 9119 mới được làm admin"), "Sai mã admin");
+      notifyError(new Error("Mã admin không hợp lệ"), "Sai mã admin");
       return;
     }
     state.role = "admin";

--- a/style.css
+++ b/style.css
@@ -552,6 +552,8 @@ h4 {
   border: 1px solid rgba(92, 161, 255, 0.3);
   border-radius: 999px;
   padding: 4px 10px;
+  transform-origin: center;
+  transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .role-popup {


### PR DESCRIPTION
### Motivation
- Limit who can activate the Word Cloud admin UI to a single known code to prevent unauthorized poll control.
- Make each voted value visually distinct and reflect popularity by color intensity and size so top choices stand out in the UI.

### Description
- Added a deterministic `colorFromValue(value, intensity)` function to map each vote value to a stable hue and compute background, border, and text colors based on vote intensity in `src/modules/wordCloud.js`.
- Adjusted chip rendering to compute `intensity = count / max` and apply dynamic `fontSize`, `transform` scale, and the colors returned by `colorFromValue` so higher-vote items grow and darken.
- Restricted entering admin mode by prompting for a code and only allowing `9119` to set `state.role = "admin"` in `src/modules/wordCloud.js`.
- Added smoother visual transitions and `transform-origin` to `.word-cloud-item` in `style.css` for nicer scaling and color changes.

### Testing
- Ran the test suite with `npm test --silent` and all automated tests passed (`21` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14248674f48323845ac859dc60d1a6)